### PR TITLE
 Add excludeParameters functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .directory
 dist
 out
+.idea

--- a/lib/operation.ts
+++ b/lib/operation.ts
@@ -70,20 +70,28 @@ export class Operation {
     const result: Parameter[] = [];
     if (params) {
       for (let param of params) {
-        if (param.$ref) {
-          param = resolveRef(this.openApi, param.$ref);
+
+          if (param.$ref) {
+            param = resolveRef(this.openApi, param.$ref);
+          }
+          param = param as ParameterObject;
+
+          if (param.in === 'cookie') {
+            console.warn(`Ignoring cookie parameter ${this.id}.${param.name} as cookie parameters cannot be sent in XmlHttpRequests.`);
+          } else if (this.paramIsNotExcluded(param)) {
+            result.push(new Parameter(param as ParameterObject, this.options));
+          }
         }
-        param = param as ParameterObject;
-        if (param.in === 'cookie') {
-          console.warn(`Ignoring cookie parameter ${this.id}.${param.name} as cookie parameters cannot be sent in XmlHttpRequests.`);
-        } else {
-          result.push(new Parameter(param as ParameterObject, this.options));
-        }
-      }
+
     }
     return result;
   }
 
+  private paramIsNotExcluded (param: ParameterObject): boolean {
+    const excludedParameters = this.options.excludeParameters || [];
+
+    return !excludedParameters.includes(param.name);
+  }
   private collectContent(desc: ContentObject | undefined): Content[] {
     const result: Content[] = [];
     if (desc) {

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -73,4 +73,7 @@ export interface Options {
   /** Custom templates directory. Any `.handlebars` files here will be used instead of the corresponding default. */
   templates?: string;
 
+  /**  When specified, filters the generated services, excluding any param corresponding to this list of params. */
+  excludeParameters?: string[];
+
 }

--- a/ng-openapi-gen-schema.json
+++ b/ng-openapi-gen-schema.json
@@ -135,6 +135,13 @@
     "templates": {
       "description": "Custom templates directory. Any `.handlebars` files here will be used instead of the corresponding default.",
       "type": "string"
+    },
+    "excludeParameters": {
+      "description": "When specified, filters the generated services, excluding any param corresponding to this list of params.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-openapi-gen",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-openapi-gen",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "license": "MIT",
   "author": "Cyclos development team",
   "description": "An OpenAPI 3 codegen for Angular 6+",


### PR DESCRIPTION
This functionality is very useful when you have interceptors in the angular app for some headers like  `Tenant-Code` or `X-Authorization` and dont need to pass it to the service methods.

[Angular Interceptors Documentation](https://angular.io/guide/http#intercepting-requests-and-responses)
