### PR TITLE
feat: parse security

### DIFF
--- a/lib/operation.ts
+++ b/lib/operation.ts
@@ -93,13 +93,14 @@ export class Operation {
     return result;
   }
 
-  private collectSecurity(params: (SecurityRequirementObject | ReferenceObject)[] | undefined): Security[][] {
+  private collectSecurity(params: (SecurityRequirementObject)[] | undefined): Security[][] {
     if (!params) { return []; }
 
-    return params.map(param => {
+    return params.map((param) => {
       return Object.keys(param).map(key => {
+        const scope = param[key];
         const security: SecuritySchemeObject = resolveRef(this.openApi, `#/components/securitySchemes/${key}`);
-        return new Security(key, security, this.options);
+        return new Security(key, security, scope, this.options);
       });
     });
   }

--- a/lib/operation.ts
+++ b/lib/operation.ts
@@ -102,7 +102,7 @@ export class Operation {
         const keys = Object.keys(param);
         keys.forEach((key) => {
           const security: SecuritySchemeObject = resolveRef(this.openApi, `#/components/securitySchemes/${key}`);
-          result.push(new Security(security, this.options));
+          result.push(new Security(key, security, this.options));
         });
       }
     }

--- a/lib/security.ts
+++ b/lib/security.ts
@@ -3,7 +3,7 @@ import { tsComments, tsType, methodName } from './gen-utils';
 import { Options } from './options';
 
 /**
- * An operation parameter
+ * An operation security
  */
 export class Security {
 

--- a/lib/security.ts
+++ b/lib/security.ts
@@ -1,0 +1,25 @@
+import { SecuritySchemeObject } from 'openapi3-ts';
+import { tsComments, tsType, methodName } from './gen-utils';
+import { Options } from './options';
+
+/**
+ * An operation parameter
+ */
+export class Security {
+
+  var: string;
+  name: string;
+  tsComments: string;
+  required: boolean;
+  in: string;
+  type: string;
+
+  constructor(public spec: SecuritySchemeObject, options: Options) {
+    this.name = spec.name || '';
+    this.var = methodName(this.name);
+    this.tsComments = tsComments(spec.description || '', 2);
+    this.in = spec.in || 'header';
+    this.required = this.in === 'path' || spec.required || false;
+    this.type = tsType(spec.schema, options);
+  }
+}

--- a/lib/security.ts
+++ b/lib/security.ts
@@ -14,9 +14,9 @@ export class Security {
   in: string;
   type: string;
 
-  constructor(public spec: SecuritySchemeObject, options: Options) {
+  constructor(key: string, public spec: SecuritySchemeObject, options: Options) {
     this.name = spec.name || '';
-    this.var = methodName(this.name);
+    this.var = methodName(key);
     this.tsComments = tsComments(spec.description || '', 2);
     this.in = spec.in || 'header';
     this.required = this.in === 'path' || spec.required || false;

--- a/lib/security.ts
+++ b/lib/security.ts
@@ -27,7 +27,7 @@ export class Security {
   in: string;
   type: string;
 
-  constructor(key: string, public spec: SecuritySchemeObject, options: Options) {
+  constructor(key: string, public spec: SecuritySchemeObject, public scope: string[] = [], options: Options) {
     this.name = spec.name || '';
     this.var = methodName(key);
     this.tsComments = tsComments(spec.description || '', 2);

--- a/lib/security.ts
+++ b/lib/security.ts
@@ -6,11 +6,24 @@ import { Options } from './options';
  * An operation security
  */
 export class Security {
-
+  /**
+   * variable name
+   */
   var: string;
+
+  /**
+   * Header Name
+   */
   name: string;
+
+  /**
+   * Property Description
+   */
   tsComments: string;
-  required: boolean;
+
+  /**
+   * Location of security parameter
+   */
   in: string;
   type: string;
 
@@ -19,7 +32,6 @@ export class Security {
     this.var = methodName(key);
     this.tsComments = tsComments(spec.description || '', 2);
     this.in = spec.in || 'header';
-    this.required = this.in === 'path' || spec.required || false;
     this.type = tsType(spec.schema, options);
   }
 }

--- a/lib/service.ts
+++ b/lib/service.ts
@@ -27,9 +27,8 @@ export class Service extends GenType {
       for (const parameter of operation.parameters) {
         this.collectImports(parameter.spec.schema);
       }
-      // console.log(operation);
-      for (const security of operation.security) {
-        this.collectImports(security.spec.schema);
+      for (const securityGroup of operation.security) {
+        securityGroup.forEach(security => this.collectImports(security.spec.schema));
       }
       if (operation.requestBody) {
         for (const content of operation.requestBody.content) {

--- a/lib/service.ts
+++ b/lib/service.ts
@@ -16,7 +16,7 @@ export class Service extends GenType {
 
     this.typeName = serviceClass(typeName(tag.name), options);
     this.fileName = fileName(this.typeName);
-    // Angular standards demmand that services have a period separating them
+    // Angular standards demand that services have a period separating them
     if (this.fileName.endsWith('-service')) {
       this.fileName = this.fileName.substring(0, this.fileName.length - '-service'.length) + '.service';
     }
@@ -26,6 +26,10 @@ export class Service extends GenType {
     for (const operation of operations) {
       for (const parameter of operation.parameters) {
         this.collectImports(parameter.spec.schema);
+      }
+      // console.log(operation);
+      for (const security of operation.security) {
+        this.collectImports(security.spec.schema);
       }
       if (operation.requestBody) {
         for (const content of operation.requestBody.content) {

--- a/templates/operationResponse.handlebars
+++ b/templates/operationResponse.handlebars
@@ -5,7 +5,10 @@
 
 {{#operation.parameters}}
       rb.{{in}}('{{{name}}}', params.{{var}});
-{{/operation.parameters}}{{#requestBody}}      rb.body(params.body, '{{{mediaType}}}');
+{{/operation.parameters}}
+
+{{#requestBody}}
+      rb.body(params.body, '{{{mediaType}}}');
 {{/requestBody}}
     }
     return this.http.request(rb.build({


### PR DESCRIPTION
## Problem
Currently, security information in the openApi file is not being parsed by the generator. Instead the documentation just recommends using HTTP interceptors.

## Solution
Added basic parsing of the security schema into operations object for use in templates. I didn't add the security to the template as this will require more thought on how best to handle and may be best left to custom templates.