### PR TITLE
fix: remove HttpClientModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ use `forRoot` method of `ApiModule` and set the `rootUrl` property from there.
     AppComponent
   ],
   imports: [
+    HttpClientModule
     ApiModule.forRoot({ rootUrl: 'https://www.example.com/api' }),
   ],
   bootstrap: [

--- a/templates/module.handlebars
+++ b/templates/module.handlebars
@@ -1,6 +1,6 @@
 /* tslint:disable */
-import { NgModule, ModuleWithProviders } from '@angular/core';
-import { HttpClientModule } from '@angular/common/http';
+import { NgModule, ModuleWithProviders, SkipSelf, Optional } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
 import { {{configurationClass}}, {{configurationParams}} } from './{{configurationFile}}';
 
 {{#services}}import { {{typeName}} } from './services/{{fileName}}';
@@ -8,15 +8,10 @@ import { {{configurationClass}}, {{configurationParams}} } from './{{configurati
 
 /**
  * Module that provides all services and configuration.
- * Also exports Angular's `HttpClientModule`, as it is required for all services.
  */
 @NgModule({
-  imports: [
-    HttpClientModule
-  ],
-  exports: [
-    HttpClientModule
-  ],
+  imports: [],
+  exports: [],
   declarations: [],
   providers: [
 {{#services}}    {{typeName}},
@@ -34,6 +29,19 @@ export class {{moduleClass}} {
           useValue: params
         }
       ]
+    }
+  }
+
+  constructor( 
+    @Optional() @SkipSelf() parentModule: ApiModule,
+    @Optional() http: HttpClient
+  ) {
+    if (parentModule) {
+      throw new Error('ApiModule is already loaded. Import in your base AppModule only.');
+    }
+    if (!http) {
+      throw new Error('You need to import the HttpClientModule in your AppModule! \n' +
+      'See also https://github.com/angular/angular/issues/20575');
     }
   }
 }


### PR DESCRIPTION
Remove HTTPClientModule and replace with a constructor check.

HTTPClientModule should only be declared once in a project. By removing the import and replacing with a constructor check, there is more flexibility in the import structure of the module.

## Breaking Change
HttpClientModule no imported by the module