### PR TITLE
Use config-provided module name in module template

### DIFF
--- a/templates/module.handlebars
+++ b/templates/module.handlebars
@@ -33,11 +33,11 @@ export class {{moduleClass}} {
   }
 
   constructor( 
-    @Optional() @SkipSelf() parentModule: ApiModule,
+    @Optional() @SkipSelf() parentModule: {{moduleClass}},
     @Optional() http: HttpClient
   ) {
     if (parentModule) {
-      throw new Error('ApiModule is already loaded. Import in your base AppModule only.');
+      throw new Error('{{moduleClass}} is already loaded. Import in your base AppModule only.');
     }
     if (!http) {
       throw new Error('You need to import the HttpClientModule in your AppModule! \n' +


### PR DESCRIPTION
In case user overrides module option in config file, he or she generates incorrect module file because it refers to default module name (ApiModule), that doesn't exist in updated module. I updated the template to reflect overridden config parameter