### PR TITLE
Change incorrect ternary expression

### DIFF
--- a/templates/requestBuilder.handlebars
+++ b/templates/requestBuilder.handlebars
@@ -165,7 +165,7 @@ export class {{ requestBuilderClass }} {
       const value = this._header.get(param);
       if (value instanceof Array) {
         for (const item of value) {
-          httpHeaders = httpHeaders.append(param, (item !== undefined && item !== null ? item || '').toString());
+          httpHeaders = httpHeaders.append(param, (item !== undefined && item !== null ? item : '').toString());
         }
       } else {
         httpHeaders = httpHeaders.set(param, (value !== undefined && value !== null ? value : '').toString());


### PR DESCRIPTION
I ran ng-openapi-gen with the latest fix to prevent duplicate entries and got an error on `request-builder.ts:168:100`.

This fixed the issue for me. It's also one of my first PR's so if you need anything else, let me know.