### PR TITLE
Add support for $ref in responses

### DIFF
--- a/lib/operation.ts
+++ b/lib/operation.ts
@@ -128,10 +128,15 @@ export class Operation {
 
   private collectResponses(): { success: Response | undefined, all: Response[] } {
     let successResponse: Response | undefined = undefined;
+    let responseDesc = undefined;
     const allResponses: Response[] = [];
     const responses = this.spec.responses || {};
     for (const statusCode of Object.keys(responses)) {
-      const responseDesc = responses[statusCode] as ResponseObject;
+      if (responses[statusCode].$ref) {
+        responseDesc = resolveRef(this.openApi, responses[statusCode].$ref);
+      } else {
+        responseDesc = responses[statusCode] as ResponseObject;
+      }
       const response = new Response(
         statusCode,
         responseDesc.description || '',

--- a/test/all-operations.json
+++ b/test/all-operations.json
@@ -308,6 +308,16 @@
           }
         }
       }
+    },
+    "/path5": {
+      "get": {
+        "summary": "A path that contains a reference to response objects",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/RefResp"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -354,6 +364,18 @@
         "description": "Cookie param",
         "schema": {
           "type": "string"
+        }
+      }
+    },
+    "responses": {
+      "RefResp": {
+        "description": "I am a response",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object"
+            }
+          }
         }
       }
     }

--- a/test/all-operations.spec.ts
+++ b/test/all-operations.spec.ts
@@ -102,7 +102,7 @@ describe('Generation tests using all-operations.json', () => {
     const noTag = gen.services.get('noTag');
     expect(noTag).toBeDefined();
     if (!noTag) return;
-    expect(noTag.operations.length).toBe(3);
+    expect(noTag.operations.length).toBe(4);
 
     const ts = gen.templates.apply('service', noTag);
     const parser = new TypescriptParser();
@@ -394,5 +394,21 @@ describe('Generation tests using all-operations.json', () => {
     expect((vars[5].successResponse as Content).mediaType).toBe('image/*');
     expect((vars[5].successResponse as Content).type).toBe('Blob');
 
+  });
+
+  it('GET /path5', () => {
+    const operation = gen.operations.get('path5Get');
+    expect(operation).toBeDefined();
+    if (!operation) return;
+    expect(operation.path).toBe('/path5');
+    expect(operation.method).toBe('get');
+    expect(operation.allResponses.length).toBe(1);
+    const success = operation.successResponse;
+    if (success) {
+      const json = success.content.find(c => c.mediaType === 'application/json');
+      expect(json).toBeDefined();
+      const resp200 = operation.allResponses.find(r => r.statusCode === '200');
+      expect(resp200).toBe(success);
+    }
   });
 });


### PR DESCRIPTION
This PR adds support for reusable responses ($ref) as described in:
- https://swagger.io/docs/specification/describing-responses/
- https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#responses-object

Unit tests added to cover the new functionality.
Bye and thanks for this great lib! 