### PR TITLE
Delete temp folder windows fix

### DIFF
--- a/lib/ng-openapi-gen.ts
+++ b/lib/ng-openapi-gen.ts
@@ -3,7 +3,6 @@ import fs from 'fs-extra';
 import $RefParser, { HTTPResolverOptions } from 'json-schema-ref-parser';
 import mkdirp from 'mkdirp';
 import path from 'path';
-import * as Path from 'path';
 import { parseOptions } from './cmd-args';
 import { HTTP_METHODS, methodName, simpleName, syncDirs } from './gen-utils';
 import { Globals } from './globals';
@@ -106,19 +105,19 @@ export class NgOpenApiGen {
     console.info(`Generation from ${this.options.input} finished with ${models.length} models and ${services.length} services.`);
   }
 
-  private deleteFolderRecursive(path: string) {
-    if (fs.existsSync(path)) {
-      fs.readdirSync(path).forEach((file: any) => {
-        const curPath = Path.join(path, file);
+  private deleteFolderRecursive(folder: string) {
+    if (fs.existsSync(folder)) {
+      fs.readdirSync(folder).forEach((file: any) => {
+        const curPath = path.join(folder, file);
         if (fs.lstatSync(curPath).isDirectory()) { // recurse
           this.deleteFolderRecursive(curPath);
         } else { // delete file
           fs.unlinkSync(curPath);
         }
       });
-      fs.rmdirSync(path);
+      fs.rmdirSync(folder);
     }
-  };
+  }
 
   private write(template: string, model: any, baseName: string, subDir?: string) {
     const ts = this.templates.apply(template, model);


### PR DESCRIPTION
Error on API generation from xxx.json: Error: ENOTEMPTY: directory not empty, rmdir 'xxx/api$' #94 

Was actually an issue in rimraf: https://github.com/isaacs/rimraf/issues/25

Used a different approach that should work in windows: https://stackoverflow.com/questions/18052762/remove-directory-which-is-not-empty/32197381