### PR TITLE
OpenAPI parameter options are not used in services

### DIFF
--- a/lib/parameter.ts
+++ b/lib/parameter.ts
@@ -27,9 +27,10 @@ export class Parameter {
     this.type = tsType(spec.schema, options);
     this.style = spec.style;
     this.explode = spec.explode;
+    this.parameterOptions = this.createParameterOptions();
   }
 
-  get parameterOptions(): string {
+  createParameterOptions(): string {
     const options: any = {};
     if (this.style) {
       options.style = this.style;

--- a/templates/operationResponse.handlebars
+++ b/templates/operationResponse.handlebars
@@ -4,7 +4,7 @@
     if (params) {
 
 {{#operation.parameters}}
-      rb.{{in}}('{{{name}}}', params{{{varAccess}}});
+      rb.{{in}}('{{{name}}}', params{{{varAccess}}}, {{{parameterOptions}}});
 {{/operation.parameters}}
 
 {{#requestBody}}


### PR DESCRIPTION
Parameter options are created in `parameter.ts`, but are never actually used in `operationResponse.handlebars`, resulting in parameters of deepObject style being sent to servers incorrectly. The changes below fix this by adding `parameterOptions` to the request builder query parameters.
Changes to `parameter.ts` are crucial, as handlebars is unfortunately unable to output the stringified JSON using a getter.