### PR TITLE
Clarified array type

### DIFF
--- a/templates/requestBuilder.handlebars
+++ b/templates/requestBuilder.handlebars
@@ -152,7 +152,7 @@ class QueryParameter extends Parameter {
         }
       } else {
         // Append a single parameter whose values are a comma-separated list of key,value,key,value...
-        const array = [];
+        const array: any[] = [];
         for (const key of Object.keys(this.value)) {
           const propVal = this.value[key];
           if (propVal !== null && propVal !== undefined) {


### PR DESCRIPTION
We're using strict null checks and this type clarification fixes a type mismatch issue that we're having with the generated request-builder.ts.