### PR TITLE
Don't convert booleans to strings in inline enum types

### DIFF
--- a/lib/gen-utils.ts
+++ b/lib/gen-utils.ts
@@ -236,7 +236,7 @@ function toType(schemaOrRef: SchemaObject | ReferenceObject | undefined, options
   // Inline enum
   const enumValues = schema.enum || [];
   if (enumValues.length > 0) {
-    if (type === 'number' || type === 'integer') {
+    if (type === 'number' || type === 'integer' || type === 'boolean') {
       return enumValues.join(' | ');
     } else {
       return enumValues.map(v => `'${jsesc(v)}'`).join(' | ');

--- a/test/all-types.json
+++ b/test/all-types.json
@@ -422,6 +422,12 @@
                   3
                 ]
               },
+              "boolEnumProp": {
+                "type": "boolean",
+                "enum": [
+                  false
+                ]
+              },
               "nestedObject": {
                 "type": "object",
                 "properties": {

--- a/test/all-types.spec.ts
+++ b/test/all-types.spec.ts
@@ -314,7 +314,7 @@ describe('Generation tests using all-types.json', () => {
       expect(ast.declarations[0]).toEqual(jasmine.any(InterfaceDeclaration));
       const decl = ast.declarations[0] as InterfaceDeclaration;
       expect(decl.name).toBe('Container');
-      expect(decl.properties.length).toBe(22);
+      expect(decl.properties.length).toBe(23);
 
       // Assert the simple types
       function assertProperty(name: string, type: string, required = false) {
@@ -348,6 +348,7 @@ describe('Generation tests using all-types.json', () => {
       assertProperty('dynamic', '{ [key: string]: XYRefObject }');
       assertProperty('stringEnumProp', '\'a\' | \'b\' | \'c\'');
       assertProperty('intEnumProp', '1 | 2 | 3');
+      assertProperty('boolEnumProp', 'false');
 
       done();
     });


### PR DESCRIPTION
Using the following OpenAPI type definition

```
objectPropertyName:
  enum:
   - false
  type: boolean
```

leads to the following interface definition being generated:

```
objectPropertyName: 'false'
```

This property fixes that to generate `objectPropertyName: false` instead.