### PR TITLE
Update operation whitespacing

### DIFF
--- a/templates/operationParameters.handlebars
+++ b/templates/operationParameters.handlebars
@@ -1,5 +1,9 @@
 params{{^operation.parametersRequired}}?{{/operation.parametersRequired}}: {
-{{#operation.parameters}}{{tsComments}}{{{var}}}{{^required}}?{{/required}}: {{{type}}};{{#tsComments}}
-{{/tsComments}}{{/operation.parameters}}{{#requestBody}}  {{{../operation.requestBody.tsComments}}}body{{^../operation.requestBody.required}}?{{/../operation.requestBody.required
-  }}: {{{type}}}{{/requestBody}}
+{{#operation.parameters}}
+{{tsComments}}{{{var}}}{{^required}}?{{/required}}: {{{type}}};{{#tsComments}}{{/tsComments}}
+{{/operation.parameters}}
+{{#requestBody}}
+{{{../operation.requestBody.tsComments}}}body{{^../operation.requestBody.required}}?{{/../operation.requestBody.required
+}}: {{{type}}}
+{{/requestBody}}
   }

--- a/templates/operationResponse.handlebars
+++ b/templates/operationResponse.handlebars
@@ -9,6 +9,7 @@
       rb.body(params.body, '{{{mediaType}}}');
 {{/requestBody}}
     }
+
     return this.http.request(rb.build({
       responseType: '{{responseType}}',
       accept: '{{accept}}'

--- a/templates/operationResponse.handlebars
+++ b/templates/operationResponse.handlebars
@@ -2,11 +2,9 @@
 
     const rb = new {{@root.requestBuilderClass}}(this.rootUrl, {{@root.typeName}}.{{operation.pathVar}}, '{{operation.method}}');
     if (params) {
-
 {{#operation.parameters}}
       rb.{{in}}('{{{name}}}', params{{{varAccess}}}, {{{parameterOptions}}});
 {{/operation.parameters}}
-
 {{#requestBody}}
       rb.body(params.body, '{{{mediaType}}}');
 {{/requestBody}}


### PR DESCRIPTION
- Remove blank lines in the operationParameters when an endpoint does not have either params, a body or both
- Remove the double indentation for the body param
- Remove the blank lines in the if(params) block in the operationResponse
- Add a blank line between the if(params) block and the request block