### PR TITLE
Fix explode false condition

### DIFF
--- a/lib/parameter.ts
+++ b/lib/parameter.ts
@@ -36,7 +36,7 @@ export class Parameter {
     if (this.style) {
       options.style = this.style;
     }
-    if (this.explode) {
+    if (!!this.explode === this.explode) {
       options.explode = this.explode;
     }
     return JSON.stringify(options);

--- a/test/all-operations.json
+++ b/test/all-operations.json
@@ -88,6 +88,19 @@
             }
           },
           {
+            "name": "get4",
+            "description": "GET param 4",
+            "in": "query",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
             "name": "=",
             "description": "Should be escaped",
             "in": "query",

--- a/test/all-operations.spec.ts
+++ b/test/all-operations.spec.ts
@@ -159,7 +159,7 @@ describe('Generation tests using all-operations.json', () => {
     expect(operation.tags).toContain('tag1');
     expect(operation.path).toBe('/path1');
     expect(operation.method).toBe('get');
-    expect(operation.parameters.length).toBe(8); // 2 shared, 6 own
+    expect(operation.parameters.length).toBe(9); // 2 shared, 7 own
     const params = operation.parameters;
     expect(params[0].name).toBe('common1');
     expect(params[0].type).toBe('RefString');
@@ -178,21 +178,25 @@ describe('Generation tests using all-operations.json', () => {
     expect(params[4].varAccess).toBe('.get3');
     expect(params[4].type).toBe('boolean');
     expect(params[4].in).toBe('query');
-    expect(params[5].name).toBe('=');
-    expect(params[5].var).toBe('\'=\'');
-    expect(params[5].varAccess).toBe('[\'=\']');
-    expect(params[5].type).toBe('string');
-    expect(params[5].in).toBe('query');
-    expect(params[6].name).toBe('123');
-    expect(params[6].var).toBe('\'123\'');
-    expect(params[6].varAccess).toBe('[\'123\']');
+    expect(params[5].name).toBe('get4');
+    expect(params[5].type).toBe('Array<string>');
+    expect(params[5].style).toBe('form');
+    expect(params[5].explode).toBe(false);
+    expect(params[6].name).toBe('=');
+    expect(params[6].var).toBe('\'=\'');
+    expect(params[6].varAccess).toBe('[\'=\']');
     expect(params[6].type).toBe('string');
     expect(params[6].in).toBe('query');
-    expect(params[7].name).toBe('a-b');
-    expect(params[7].var).toBe('\'a-b\'');
-    expect(params[7].varAccess).toBe('[\'a-b\']');
+    expect(params[7].name).toBe('123');
+    expect(params[7].var).toBe('\'123\'');
+    expect(params[7].varAccess).toBe('[\'123\']');
     expect(params[7].type).toBe('string');
     expect(params[7].in).toBe('query');
+    expect(params[8].name).toBe('a-b');
+    expect(params[8].var).toBe('\'a-b\'');
+    expect(params[8].varAccess).toBe('[\'a-b\']');
+    expect(params[8].type).toBe('string');
+    expect(params[8].in).toBe('query');
     expect(operation.requestBody).toBeUndefined();
     expect(operation.allResponses.length).toBe(2);
     const success = operation.successResponse;

--- a/test/parameter.spec.ts
+++ b/test/parameter.spec.ts
@@ -1,0 +1,83 @@
+import { Parameter } from '../lib/parameter';
+
+const parameterNotExploded = new Parameter({ 
+    explode: false, 
+    name: 'par1', 
+    in: 'query', 
+    description: 'Description of par1', 
+    style: 'form',
+    schema: { 
+      type: 'array', 
+      items: { 
+        type: 'string' 
+      }
+    } 
+  }, 
+  { 
+    input: 'fake.json'
+  }, 
+  {
+    openapi: '', 
+    info: {
+      title: 'fake open api',
+      version: '3.0.0'
+    },
+    paths: []
+  });
+
+const parameterExploded = new Parameter({ 
+    explode: true,
+    name: 'par1', 
+    in: 'query', 
+    description: 'Description of par1', 
+    style: 'form',
+    schema: { 
+      type: 'array', 
+      items: { 
+        type: 'string' 
+      }
+    } 
+  }, 
+  { 
+    input: 'fake.json'
+  }, 
+  {
+    openapi: '', 
+    info: {
+      title: 'fake open api',
+      version: '3.0.0'
+    },
+    paths: []
+  });
+
+  const parameter = new Parameter({ 
+    name: 'par1', 
+    in: 'query', 
+    description: 'Description of par1', 
+    schema: { 
+      type: 'array', 
+      items: { 
+        type: 'string' 
+      }
+    } 
+  }, 
+  { 
+    input: 'fake.json'
+  }, 
+  {
+    openapi: '', 
+    info: {
+      title: 'fake open api',
+      version: '3.0.0'
+    },
+    paths: []
+  });
+
+describe('Parameters constructor', () => {
+  it('paramter options should be serialized', () => {
+    expect(parameterNotExploded.parameterOptions).toBe("{\"style\":\"form\",\"explode\":false}");
+    expect(parameterExploded.parameterOptions).toBe("{\"style\":\"form\",\"explode\":true}");
+    expect(parameter.parameterOptions).toBe("{}");
+
+  });
+});


### PR DESCRIPTION
When explode is set to false in openApi, the Parameter class is never handling that because of the `if (this.explode)`. As `explode` is `true` by default, the requestBuilder is never executing the specific logic implemented in case of `explode=false`.

This PR solves that issue.