### PR TITLE
Fix tags parsing into namespaces

### DIFF
--- a/lib/gen-utils.ts
+++ b/lib/gen-utils.ts
@@ -51,14 +51,14 @@ export function modelFile(pathToModels: string, name: string, options: Options):
 }
 
 /**
- * Returns the namespace path, that is, the part before the last '.' splitted by '/' instead of '.'.
+ * Returns the namespace path, that is, the part before the last '.' split by '/' instead of '.'.
  * If there's no namespace, returns undefined.
  */
 export function namespace(name: string): string | undefined {
   name = name.replace(/^\.+/g, '');
   name = name.replace(/\.+$/g, '');
   const pos = name.lastIndexOf('.');
-  return pos < 0 ? undefined : name.substring(0, pos).replace('.', '/');
+  return pos < 0 ? undefined : name.substring(0, pos).replace(/\./g, '/');
 }
 
 /**

--- a/test/all-operations.json
+++ b/test/all-operations.json
@@ -23,6 +23,9 @@
       "name": "tag2"
     },
     {
+      "name": "tag.tag2.tag3.tag4.tag5"
+    },
+    {
       "name": "unused",
       "description": "Unused description"
     }
@@ -340,6 +343,9 @@
     },
     "/path5": {
       "get": {
+        "tags": [
+          "tag.tag2.tag3.tag4.tag5"
+        ],
         "summary": "A path that contains a reference to response objects",
         "responses": {
           "200": {

--- a/test/all-operations.spec.ts
+++ b/test/all-operations.spec.ts
@@ -15,7 +15,7 @@ describe('Generation tests using all-operations.json', () => {
   });
 
   it('Tags', () => {
-    expect(gen.services.size).toBe(3);
+    expect(gen.services.size).toBe(4);
   });
 
   it('Tag 1', done => {
@@ -98,11 +98,19 @@ describe('Generation tests using all-operations.json', () => {
     });
   });
 
+  it('Tag with nesting', () => {
+    const tagWithNesting = gen.services.get('tag.tag2.tag3.tag4.tag5');
+    expect(tagWithNesting).toBeDefined();
+    if (!tagWithNesting) return;
+
+    expect(tagWithNesting.namespace).toBe('tag/tag2/tag3/tag4');
+  });
+
   it('No tag', done => {
     const noTag = gen.services.get('noTag');
     expect(noTag).toBeDefined();
     if (!noTag) return;
-    expect(noTag.operations.length).toBe(4);
+    expect(noTag.operations.length).toBe(3);
 
     const ts = gen.templates.apply('service', noTag);
     const parser = new TypescriptParser();


### PR DESCRIPTION
Tags are sliced only by the first dot that prevents create nested directory structure more than 2 levels deep.
This pr fix #133 