### PR TITLE
Attempt to fix operator precedence based on PR-110

### DIFF
--- a/lib/gen-utils.ts
+++ b/lib/gen-utils.ts
@@ -183,7 +183,11 @@ export function tsType(schemaOrRef: SchemaOrRef | undefined, options: Options, o
   // An union of types
   const union = schema.oneOf || schema.anyOf || [];
   if (union.length > 0) {
-    return union.map(u => tsType(u, options, openApi, container)).join(' | ');
+    if (union.length > 1) {
+      return `(${union.map(u => tsType(u, options, openApi, container)).join(' | ')})`;
+    } else {
+      return union.map(u => tsType(u, options, openApi, container)).join(' | ');
+    }
   }
 
   const type = schema.type || 'any';

--- a/test/all-types.spec.ts
+++ b/test/all-types.spec.ts
@@ -149,7 +149,7 @@ describe('Generation tests using all-types.json', () => {
       const decl = ast.declarations[0] as TypeAliasDeclaration;
       expect(decl.name).toBe('Union');
       const text = ts.substring(decl.start || 0, decl.end || ts.length);
-      expect(text).toBe('export type Union = { [key: string]: any } | RefEnum | RefIntEnum | RefNamedIntEnum | Container;');
+      expect(text).toBe('export type Union = ({ [key: string]: any } | RefEnum | RefIntEnum | RefNamedIntEnum | Container);');
       done();
     });
   });
@@ -166,7 +166,7 @@ describe('Generation tests using all-types.json', () => {
       const decl = ast.declarations[0] as TypeAliasDeclaration;
       expect(decl.name).toBe('Disjunct');
       const text = ts.substring(decl.start || 0, decl.end || ts.length);
-      expect(text).toBe('export type Disjunct = { \'ref\'?: ReferencedInNullableOneOf } | ABRefObject | XYRefObject | ReferencedInOneOf | EscapedProperties;');
+      expect(text).toBe('export type Disjunct = ({ \'ref\'?: ReferencedInNullableOneOf } | ABRefObject | XYRefObject | ReferencedInOneOf | EscapedProperties);');
       done();
     });
   });
@@ -370,7 +370,7 @@ describe('Generation tests using all-types.json', () => {
       assertProperty('arrayOfABRefObjectsProp', 'Array<ABRefObject>');
       assertProperty('arrayOfAnyProp', 'Array<any>');
       assertProperty('nestedObject', '{ \'p1\'?: string, \'p2\'?: number, ' +
-        '\'deeper\'?: { \'d1\': ABRefObject, \'d2\'?: string | Array<ABRefObject> | number } }');
+        '\'deeper\'?: { \'d1\': ABRefObject, \'d2\'?: (string | Array<ABRefObject> | number) } }');
       assertProperty('dynamic', '{ [key: string]: XYRefObject }');
       assertProperty('stringEnumProp', '\'a\' | \'b\' | \'c\'');
       assertProperty('intEnumProp', '1 | 2 | 3');


### PR DESCRIPTION
I did an attempt at merging all of PR-110 but I was unable to resolve the diff with master on my own. Instead I cherry-picked the solution for #111 to try and see if we can merge the solution for #111 separately. I did wonder how much of a problem the, in some cases unnecessary, parenthesis are as demonstrated by the changed tests?