### PR TITLE
Support json media types with charset

### DIFF
--- a/lib/operation-variant.ts
+++ b/lib/operation-variant.ts
@@ -49,7 +49,7 @@ export class OperationVariant {
     }
 
     mediaType = mediaType.toLowerCase();
-    if (mediaType.endsWith('/json') || mediaType.endsWith('+json')) {
+    if (mediaType.includes('/json') || mediaType.includes('+json')) {
       return 'json';
     } else if (mediaType.startsWith('text/')) {
       return 'text';


### PR DESCRIPTION
The inferResponseType checks for ending of the media type:  
```
if (mediaType.endsWith('/json') || mediaType.endsWith('+json')) {
```
But it's quite usual to have it like this:
```
  content:
    application/json; charset=utf-8:
      ...
```
Which breaks the inference and makes the responseType to be "blob".
**Proposed solution:**
It's enough for media type to _include_ the "/json" and "+json" strings, not _endsWith_.