### PR TITLE
Migrated to the new argparse v2 syntax

### DIFF
--- a/lib/cmd-args.ts
+++ b/lib/cmd-args.ts
@@ -10,8 +10,7 @@ const DefaultConfig = 'ng-openapi-gen.json';
 
 function createParser() {
   const argParser = new ArgumentParser({
-    version: pkg.version,
-    addHelp: true,
+    add_help: true,
     description: `
 Generator for API clients described with OpenAPI 3.0 specification for
 Angular 6+ projects. Requires a configuration file, which defaults to
@@ -25,14 +24,23 @@ argument could be set as '--service-suffix Suffix'
 As the only required argument is the input for OpenAPI specification,
 a configuration file is only required if no --input argument is set.`.trim()
   });
-  argParser.addArgument(
-    ['-c', '--config'],
+  argParser.add_argument(
+    '-v',
+    '--version',
+    {
+      action: 'version',
+      version: pkg.version
+    }
+  );
+  argParser.add_argument(
+    '-c',
+    '--config',
     {
       help: `
 The configuration file to be used. If not specified, assumes that
 ${DefaultConfig} in the current directory`.trim(),
       dest: 'config',
-      defaultValue: `./${DefaultConfig}`
+      default: `./${DefaultConfig}`
     }
   );
   const props = schema.properties;
@@ -51,7 +59,7 @@ ${DefaultConfig} in the current directory`.trim(),
     if (kebab !== key) {
       names.push('--' + kebab);
     }
-    argParser.addArgument(names, {
+    argParser.add_argument(...(names as [string]), {
       help: desc.description,
       dest: key
     });
@@ -64,7 +72,7 @@ ${DefaultConfig} in the current directory`.trim(),
  */
 export function parseOptions(sysArgs?: string[]): Options {
   const argParser = createParser();
-  const args = argParser.parseArgs(sysArgs);
+  const args = argParser.parse_args(sysArgs);
   let options: any = {};
   if (args.config) {
     if (fs.existsSync(args.config)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "license": "MIT",
       "dependencies": {
         "@loopback/openapi-v3-types": "^1.2.1",
-        "@types/argparse": "^1.0.38",
+        "@types/argparse": "^2.0.10",
         "@types/fs-extra": "^9.0.8",
         "@types/jsesc": "^2.5.1",
         "@types/json-schema": "^7.0.7",
@@ -192,9 +192,9 @@
       }
     },
     "node_modules/@types/argparse": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
-      "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA=="
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-2.0.10.tgz",
+      "integrity": "sha512-C4wahC3gz3vQtvPazrJ5ONwmK1zSDllQboiWvpMM/iOswCYfBREFnjFbq/iWKIVOCl8+m5Pk6eva6/ZSsDuIGA=="
     },
     "node_modules/@types/fs-extra": {
       "version": "9.0.12",
@@ -2531,9 +2531,9 @@
       }
     },
     "@types/argparse": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
-      "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA=="
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-2.0.10.tgz",
+      "integrity": "sha512-C4wahC3gz3vQtvPazrJ5ONwmK1zSDllQboiWvpMM/iOswCYfBREFnjFbq/iWKIVOCl8+m5Pk6eva6/ZSsDuIGA=="
     },
     "@types/fs-extra": {
       "version": "9.0.12",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@loopback/openapi-v3-types": "^1.2.1",
-    "@types/argparse": "^1.0.38",
+    "@types/argparse": "^2.0.10",
     "@types/fs-extra": "^9.0.8",
     "@types/jsesc": "^2.5.1",
     "@types/json-schema": "^7.0.7",


### PR DESCRIPTION
Should fix issue #168.

Had to also upgrade the typings for argparse, as the current version doesn't support the actual argparse 2.0.1 syntax

Line 62 is questionable. I didn't want to rewrite the rest of the function to stay as consistent to your style as possible. That's why I chose to just typecast the argument to make typescript shut up. Not elegant, but it seems to work correctly, pass the tests and show the correct help message.