### PR TITLE
Improve typescript pair type in request-builder.ts

### DIFF
--- a/templates/requestBuilder.handlebars
+++ b/templates/requestBuilder.handlebars
@@ -253,7 +253,7 @@ export class RequestBuilder {
     }
     if (this._bodyContentType === 'application/x-www-form-urlencoded' && value !== null && typeof value === 'object') {
       // Handle URL-encoded data
-      const pairs: string[][] = [];
+      const pairs: Array<[string, string]> = [];
       for (const key of Object.keys(value)) {
         let val = value[key];
         if (!(val instanceof Array)) {


### PR DESCRIPTION
With Typescript compiler option `"noUncheckedIndexedAccess": true` enabled on my project, it throw me some error.
https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/#no-unchecked-indexed-access

```ts
request-builder.ts:262:72 - error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string | number | boolean'.
262             this._bodyContent = pairs.map((p) => `${encodeURIComponent(p[0])}=${encodeURIComponent(p[1])}`).join('&');
```
`p[0]` and `p[1]` maybe be undefined according to typescript compiler with this option.


Changing type from :
```ts
const pairs: string[][] = [];
```
to :
```ts
const pairs: Array<[string, string]> = [];
```

Remove that error.

Thx a lot for your tool