### PR TITLE
fix/tags-case-sensitivity-service-generation

### DIFF
--- a/lib/operation.ts
+++ b/lib/operation.ts
@@ -1,4 +1,4 @@
-import { upperFirst, last } from 'lodash';
+import { upperFirst, lowerFirst, last } from 'lodash';
 import { ContentObject, MediaTypeObject, OpenAPIObject, OperationObject, ParameterObject, PathItemObject, ReferenceObject, RequestBodyObject, ResponseObject, SecurityRequirementObject, SecuritySchemeObject } from 'openapi3-ts';
 import { Content } from './content';
 import { resolveRef, typeName } from './gen-utils';
@@ -37,7 +37,7 @@ export class Operation {
     public spec: OperationObject,
     public options: Options) {
     this.path = this.path.replace(/\'/g, '\\\'');
-    this.tags = spec.tags || [];
+    this.tags = this.getTags();
     this.pathVar = `${upperFirst(id)}Path`;
     this.methodName = spec['x-operation-name'] || this.id;
 
@@ -215,4 +215,12 @@ export class Operation {
     }
   }
 
+  /**
+   * Make tags safe to fix missing operations in generated files
+   * Fix issue: https://github.com/cyclosproject/ng-openapi-gen/issues/190
+   */
+  private getTags(): string[] {
+    const tags = this.spec.tags || [];
+    return tags.map((tag) => lowerFirst(tag));
+  }
 }

--- a/test/all-operations.json
+++ b/test/all-operations.json
@@ -64,7 +64,7 @@
       "get": {
         "operationId": "path1Get",
         "tags": [
-          "tag1"
+          "Tag1"
         ],
         "description": "Path 1 GET description",
         "parameters": [


### PR DESCRIPTION
Add a method to set first tag letter to lower case when creating Operation instances.
This latter prevent the generator to override service file when two tags don't use the same case. 

Eg: Tag1 != tag1