### PR TITLE
Add HttpContext support for Angular 12+ apps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ng-openapi-gen: An OpenAPI 3 code generator for Angular
 
 This project is a NPM module that generates model interfaces and web service clients from an [OpenApi 3](https://www.openapis.org/) [specification](https://github.com/OAI/OpenAPI-Specification).
 The generated classes follow the principles of [Angular](https://angular.io/).
-The generated code is compatible with Angular 7+.
+The generated code is compatible with Angular 12+.
 
 For a generator for [Swagger 2.0](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md), use [ng-swagger-gen](https://github.com/cyclosproject/ng-swagger-gen) instead.
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "typescript": "^4.5.4"
   },
   "peerDependencies": {
-    "@angular/core": ">=7.0.0",
+    "@angular/core": ">=12.0.0",
     "rxjs": ">=6.0.0"
   },
   "devDependencies": {

--- a/templates/operationParameters.handlebars
+++ b/templates/operationParameters.handlebars
@@ -2,6 +2,7 @@ params{{^operation.parametersRequired}}?{{/operation.parametersRequired}}: {
 {{#operation.parameters}}
 {{tsComments}}{{{var}}}{{^required}}?{{/required}}: {{{type}}};{{#tsComments}}{{/tsComments}}
 {{/operation.parameters}}
+    context?: HttpContext
 {{#requestBody}}
 {{{../operation.requestBody.tsComments}}}body{{^../operation.requestBody.required}}?{{/../operation.requestBody.required
 }}: {{{type}}}

--- a/templates/operationResponse.handlebars
+++ b/templates/operationResponse.handlebars
@@ -12,7 +12,8 @@
 
     return this.http.request(rb.build({
       responseType: '{{responseType}}',
-      accept: '{{accept}}'
+      accept: '{{accept}}',
+      context: params?.context
     })).pipe(
       filter((r: any) => r instanceof HttpResponse),
       map((r: HttpResponse<any>) => {

--- a/templates/requestBuilder.handlebars
+++ b/templates/requestBuilder.handlebars
@@ -321,6 +321,9 @@ export class RequestBuilder {
 
     /** Whether to report progress on uploads / downloads */
     reportProgress?: boolean;
+
+    /** Allow passing HttpContext for HttpClient */
+    context?: HttpContext;
   }): HttpRequest<T> {
 
     options = options || {};
@@ -359,7 +362,8 @@ export class RequestBuilder {
       params: httpParams,
       headers: httpHeaders,
       responseType: options.responseType,
-      reportProgress: options.reportProgress
+      reportProgress: options.reportProgress,
+      context: options.context
     });
   }
 }

--- a/templates/requestBuilder.handlebars
+++ b/templates/requestBuilder.handlebars
@@ -1,7 +1,7 @@
 {{! WARNING! If any changes are performed in this template MUST be mirrored in `test/mock/request-builder.ts` }}
 /* tslint:disable */
 /* eslint-disable */
-import { HttpRequest, HttpParameterCodec, HttpParams, HttpHeaders } from '@angular/common/http';
+import { HttpRequest, HttpParameterCodec, HttpParams, HttpHeaders, HttpContext } from '@angular/common/http';
 
 /**
  * Custom parameter codec to correctly handle the plus sign in parameter

--- a/templates/service.handlebars
+++ b/templates/service.handlebars
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpClient, HttpResponse, HttpContext } from '@angular/common/http';
 import { {{baseServiceClass}} } from '../{{baseServiceFile}}';
 import { {{configurationClass}} } from '../{{configurationFile}}';
 import { {{responseClass}} } from '../{{responseFile}}';

--- a/test/petstore.spec.ts
+++ b/test/petstore.spec.ts
@@ -39,8 +39,7 @@ describe('Generation tests using petstore.json', () => {
         const type = createPets.parameters[0].type;
         // single optional parameters
         expect(type).toBeDefined();
-        expect(type).toContain('context?: HttpContext');
-        expect(type!.length).toBe(33);
+        expect(type!.replace(/(\r\n|\n|\r| )/gm, "")).toBe('{context?:HttpContext}');
       }
 
       const showPetById = cls.methods.find(m => m.name === 'showPetById');

--- a/test/petstore.spec.ts
+++ b/test/petstore.spec.ts
@@ -37,8 +37,10 @@ describe('Generation tests using petstore.json', () => {
       if (createPets) {
         expect(createPets.parameters.length).toBe(1);
         const type = createPets.parameters[0].type;
-        // No parameters
-        expect(type).not.toContain(':');
+        // single optional parameters
+        expect(type).toBeDefined();
+        expect(type).toContain('context?: HttpContext');
+        expect(type!.length).toBe(33);
       }
 
       const showPetById = cls.methods.find(m => m.name === 'showPetById');


### PR DESCRIPTION
Fixes https://github.com/cyclosproject/ng-openapi-gen/issues/160

Please note that it requires Angular12+