### PR TITLE
Option to use system temporary directory

### DIFF
--- a/lib/ng-openapi-gen.ts
+++ b/lib/ng-openapi-gen.ts
@@ -3,6 +3,7 @@ import fs from 'fs-extra';
 import $RefParser, { HTTPResolverOptions } from '@apidevtools/json-schema-ref-parser';
 import mkdirp from 'mkdirp';
 import path from 'path';
+import os from 'os';
 import { parseOptions } from './cmd-args';
 import { HTTP_METHODS, methodName, simpleName, syncDirs, deleteDirRecursive } from './gen-utils';
 import { Globals } from './globals';
@@ -38,6 +39,7 @@ export class NgOpenApiGen {
     }
     this.tempDir = this.outDir + '$';
 
+    this.initTempDir();
     this.initHandlebars();
     this.readTemplates();
     this.readModels();
@@ -46,6 +48,16 @@ export class NgOpenApiGen {
     // Ignore the unused models if not set to false in options
     if (this.options.ignoreUnusedModels !== false) {
       this.ignoreUnusedModels();
+    }
+  }
+
+  /**
+   * Set the temp dir to a system temporary directory if option useTempDir is set
+   */
+  initTempDir(): void {
+    if (this.options.useTempDir === true) {
+      const systemTempDir = path.join(os.tmpdir(), `ng-openapi-gen-${path.basename(this.outDir)}$`);
+      this.tempDir = systemTempDir;
     }
   }
 

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -90,4 +90,7 @@ export interface Options {
       toUse: 'arraybuffer' | 'blob' | 'json' | 'document'
     }
   };
+
+  /** When specified, will create temporary files in system temporary folder instead of next to output folder. */
+  useTempDir?: boolean;
 }

--- a/ng-openapi-gen-schema.json
+++ b/ng-openapi-gen-schema.json
@@ -181,6 +181,11 @@
           }
         }
       }
+    },
+    "useTempDir": {
+      "description": "When specified, will create temporary files in system temporary folder instead of output folder",
+      "default": false,
+      "type": "boolean"
     }
   }
 }

--- a/test/useTempDir.config.json
+++ b/test/useTempDir.config.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../ng-openapi-gen-schema.json",
+  "input": "test/useTempDir.json",
+  "output": "out/useTempDir",
+  "useTempDir": true
+}

--- a/test/useTempDir.json
+++ b/test/useTempDir.json
@@ -1,0 +1,25 @@
+{
+  "openapi": "3.0",
+  "info": {
+    "title": "Test with useTempDir",
+    "version": "1.0"
+  },
+  "paths": {
+    "/foo": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/plain": {}
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/useTempDir.spec.ts
+++ b/test/useTempDir.spec.ts
@@ -1,0 +1,21 @@
+import { OpenAPIObject } from 'openapi3-ts';
+import { NgOpenApiGen } from '../lib/ng-openapi-gen';
+import options from './useTempDir.config.json';
+import templatesSpec from './useTempDir.json';
+import os from 'os';
+
+describe('Generation tests using system temporary directory', () => {
+
+  it('Use system temp folder when useTempDir is true', () => {
+
+    const gen = new NgOpenApiGen(templatesSpec as OpenAPIObject, options);
+    gen.generate();
+
+    const tempDirectory = os.tmpdir();
+
+    expect(gen.tempDir.startsWith(tempDirectory)).toBeTrue();
+    expect(gen.tempDir.endsWith('useTempDir$')).toBeTrue();
+
+  });
+
+});

--- a/test/useTempDir.spec.ts
+++ b/test/useTempDir.spec.ts
@@ -18,4 +18,17 @@ describe('Generation tests using system temporary directory', () => {
 
   });
 
+  it('Do not use system temp folder when useTempDir is false', () => {
+
+    const optionsWithoutTempDir = { ...options };
+    optionsWithoutTempDir.useTempDir = false;
+
+    const gen = new NgOpenApiGen(templatesSpec as OpenAPIObject, optionsWithoutTempDir);
+    gen.generate();
+
+    const tempDirectory = os.tmpdir();
+    expect(gen.tempDir.startsWith(tempDirectory)).toBeFalse();
+
+  });
+
 });


### PR DESCRIPTION
As I suggested in #218 here's a PR for adding an option to use system temporary directory instead of the output directory.

I have noticed a large VSCode workspace may use a lot of CPU when a lot of files are created/deleted and VSCode wants to index the files for its search.

The benefit of this would be that the `tempDir` and all its files would not affect the workspace or repository for the code that other applications may use and react to. As earlier, only the affected files will be copied/deleted from the final output directory so the output directory changes would be limited to the changes that ng-openapi-gen detects and copies to the final output directory.

- The option `useTempDir` was added to schema and options.ts
- The function `initTempDir` in ng-openapi-gen.ts to use system temp directory if option is specified
- Two unit tests was added to test tempDir path with and without the option specified