### PR TITLE
feat: added config option for EOL

### DIFF
--- a/lib/ng-openapi-gen.ts
+++ b/lib/ng-openapi-gen.ts
@@ -13,6 +13,7 @@ import { Operation } from './operation';
 import { Options } from './options';
 import { Service } from './service';
 import { Templates } from './templates';
+import eol from 'eol';
 
 /**
  * Main generator class
@@ -108,7 +109,7 @@ export class NgOpenApiGen {
   }
 
   private write(template: string, model: any, baseName: string, subDir?: string) {
-    const ts = this.templates.apply(template, model);
+    const ts = this.setEndOfLine(this.templates.apply(template, model));
     const file = path.join(this.tempDir, subDir || '.', `${baseName}.ts`);
     const dir = path.dirname(file);
     mkdirp.sync(dir);
@@ -289,6 +290,19 @@ export class NgOpenApiGen {
       Array.prototype.push.apply(result, this.allReferencedNames(schema.items));
     }
     return result;
+  }
+
+  private setEndOfLine(text: string): string {
+    switch (this.options.endOfLineStyle) {
+      case 'cr':
+        return eol.cr(text);
+      case 'lf':
+        return eol.lf(text);
+      case 'crlf':
+        return eol.crlf(text);
+      default:
+        return eol.auto(text);
+    }
   }
 }
 

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -76,6 +76,18 @@ export interface Options {
    */
   enumStyle?: 'alias' | 'upper' | 'pascal';
 
+  /**
+   * Determines how to normalize line endings. Possible values are:
+   *
+   * - `crlf`: normalize line endings to CRLF (Windows, DOS) => \r\n
+   * - `lf` normalize line endings to LF (Unix, OS X) => \n
+   * - `cr` normalize line endings to CR (Mac OS) => \r
+   * - `auto` normalize line endings for the current operating system
+   *
+   * Defaults to 'auto'.
+   */
+  endOfLineStyle?: 'crlf' | 'lf' | 'cr' | 'auto';
+
   /** Custom templates directory. Any `.handlebars` files here will be used instead of the corresponding default. */
   templates?: string;
 

--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
 import { Globals } from './globals';
-import eol from 'eol';
 
 /**
  * Holds all templates, and know how to apply them
@@ -28,7 +27,7 @@ export class Templates {
   private parseTemplate(dir: string, file: string, handlebars: typeof Handlebars) {
     const baseName = this.baseName(file);
     if (baseName) {
-      const text = eol.auto(fs.readFileSync(path.join(dir, file), 'utf-8'));
+      const text = fs.readFileSync(path.join(dir, file), 'utf-8');
       const compiled = handlebars.compile(text);
       this.templates[baseName] = compiled;
       handlebars.registerPartial(baseName, compiled);

--- a/ng-openapi-gen-schema.json
+++ b/ng-openapi-gen-schema.json
@@ -137,6 +137,16 @@
         "pascal"
       ]
     },
+    "endOfLineStyle": {
+      "description": "Determines how to normalize line endings. Possible values are: `crlf`: normalize line endings to CRLF (Windows, DOS) => \\r\\n. `lf` normalize line endings to LF (Unix, OS X) => \\n. `cr` normalize line endings to CR (Mac OS) => \\r. `auto` normalize line endings for the current operating system. Defaults to 'auto'.",
+      "default": "auto",
+      "enum": [
+        "crlf",
+        "lf",
+        "cr",
+        "auto"
+      ]
+    },
     "templates": {
       "description": "Custom templates directory. Any `.handlebars` files here will be used instead of the corresponding default.",
       "type": "string"

--- a/test/templates.spec.ts
+++ b/test/templates.spec.ts
@@ -3,14 +3,41 @@ import { NgOpenApiGen } from '../lib/ng-openapi-gen';
 import options from './templates.config.json';
 import templatesSpec from './templates.json';
 import * as fs from 'fs';
+import { Options } from '../lib/options';
 
-const gen = new NgOpenApiGen(templatesSpec as OpenAPIObject, options);
+const gen = new NgOpenApiGen(templatesSpec as OpenAPIObject, options as Options);
+const genCr = new NgOpenApiGen(templatesSpec as OpenAPIObject, {...options, endOfLineStyle: 'cr'} as Options);
+const genLf = new NgOpenApiGen(templatesSpec as OpenAPIObject, {...options, endOfLineStyle: 'lf'} as Options);
+const genCrlf = new NgOpenApiGen(templatesSpec as OpenAPIObject, {...options, endOfLineStyle: 'crlf'} as Options);
+
 gen.generate();
 
 describe('Generation tests using templates.json', () => {
 
   it('Service template applied with custom Handlebars helper', () => {
+    genCr.generate();
     const fileContents = fs.readFileSync(fs.realpathSync(`${gen.outDir}/services/tag-1.service.ts`));
     expect(/(DESCRIPTION OF TAG1)/.test(fileContents.toString())).toBeTrue();
+  });
+
+  it('Normalize end of line to cr', () => {
+    genCr.generate();
+    const fileContents = fs.readFileSync(fs.realpathSync(`${genCr.outDir}/services/tag-1.service.ts`));
+    expect(/[\r]/.test(fileContents.toString())).toBeTrue();
+    expect(/[\n]/.test(fileContents.toString())).toBeFalse();
+  });
+
+  it('Normalize end of line to lf', () => {
+    genLf.generate();
+    const fileContents = fs.readFileSync(fs.realpathSync(`${genLf.outDir}/services/tag-1.service.ts`));
+    expect(/[\r]/.test(fileContents.toString())).toBeFalse();
+    expect(/[\n]/.test(fileContents.toString())).toBeTrue();
+  });
+
+  it('Normalize end of line to crlf', () => {
+    genCrlf.generate();
+    const fileContents = fs.readFileSync(fs.realpathSync(`${genCrlf.outDir}/services/tag-1.service.ts`));
+    expect(/[\r]/.test(fileContents.toString())).toBeTrue();
+    expect(/[\n]/.test(fileContents.toString())).toBeTrue();
   });
 });


### PR DESCRIPTION
Closes #198 
As suggested by maximebochon I added a new configuration option "endOfLineStyle" having the default value set to 'auto' (same behavior as before). I removed the eol import from template.ts because it only had overridden the template itself without the provided data. That's why I implemented it in the ng-openapi-gen.ts