### PR TITLE
Ensure all occurrences are replaced in path parameter sanitization

### DIFF
--- a/templates/requestBuilder.handlebars
+++ b/templates/requestBuilder.handlebars
@@ -117,9 +117,9 @@ class PathParameter extends Parameter {
   // @ts-ignore
   serializeValue(value: any, separator = ','): string {
     var result = typeof value === 'string' ? encodeURIComponent(value) : super.serializeValue(value, separator);
-    result = result.replace('%3D', '=');
-    result = result.replace('%3B', ';');
-    result = result.replace('%2C', ',');
+    result = result.replace(/%3D/g, '=');
+    result = result.replace(/%3B/g, ';');
+    result = result.replace(/%2C/g, ',');
     return result;
   }
 }

--- a/test/mock/request-builder.ts
+++ b/test/mock/request-builder.ts
@@ -117,9 +117,9 @@ class PathParameter extends Parameter {
   // @ts-ignore
   serializeValue(value: any, separator = ','): string {
     var result = typeof value === 'string' ? encodeURIComponent(value) : super.serializeValue(value, separator);
-    result = result.replace('%3D', '=');
-    result = result.replace('%3B', ';');
-    result = result.replace('%2C', ',');
+    result = result.replace(/%3D/g, '=');
+    result = result.replace(/%3B/g, ';');
+    result = result.replace(/%2C/g, ',');
     return result;
   }
 }

--- a/test/request-builder.spec.ts
+++ b/test/request-builder.spec.ts
@@ -70,9 +70,9 @@ describe('Request builder', () => {
     const rb = new RequestBuilder('http://localhost/api', '/operation/{p1}/{p2}/{p3}', 'post');
     rb.path('p1', 'a');
     rb.path('p2', 'b');
-    rb.path('p3', '%123/');
+    rb.path('p3', '%123==;;,,/');
     const request = rb.build();
-    expect(request.url).toBe('http://localhost/api/operation/a/b/' + encodeURIComponent('%123/'));
+    expect(request.url).toBe('http://localhost/api/operation/a/b/%25123==;;,,%2F');
   });
 
   it('Path parameter, string array value', () => {


### PR DESCRIPTION
Javascript replace only acts on the first found match if the pattern is
a string. Change the patterns to regular expressions and use the global
flag to ensure all occurrences are replaced.

This also updates the test to include some checks around the three
special characters we un-escape in this code.

We noticed this with CodeQL Security Scanning on our repository- this rule was tripped: https://github.com/github/codeql/blob/56786790fcf88b79d1d26b946ff36dfe2d6f33ac/javascript/ql/src/Security/CWE-116/IncompleteSanitization.ql