### PR TITLE
feature: adds "silent" option to reduce console output

### DIFF
--- a/lib/gen-utils.ts
+++ b/lib/gen-utils.ts
@@ -5,6 +5,7 @@ import { camelCase, deburr, kebabCase, upperCase, upperFirst } from 'lodash';
 import { OpenAPIObject, ReferenceObject, SchemaObject } from 'openapi3-ts';
 import { Options } from './options';
 import { Model } from './model';
+import { Logger } from './logger';
 
 export const HTTP_METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
 type SchemaOrRef = SchemaObject | ReferenceObject;
@@ -304,7 +305,7 @@ export function deleteDirRecursive(dir: string) {
 /**
  * Synchronizes the files from the source to the target directory. Optionally remove stale files.
  */
-export function syncDirs(srcDir: string, destDir: string, removeStale: boolean): any {
+export function syncDirs(srcDir: string, destDir: string, removeStale: boolean, logger: Logger): any {
   fs.ensureDirSync(destDir);
   const srcFiles = fs.readdirSync(srcDir);
   const destFiles = fs.readdirSync(destDir);
@@ -313,14 +314,14 @@ export function syncDirs(srcDir: string, destDir: string, removeStale: boolean):
     const destFile = path.join(destDir, file);
     if (fs.lstatSync(srcFile).isDirectory()) {
       // A directory: recursively sync
-      syncDirs(srcFile, destFile, removeStale);
+      syncDirs(srcFile, destFile, removeStale, logger);
     } else {
       // Read the content of both files and update if they differ
       const srcContent = fs.readFileSync(srcFile, { encoding: 'utf-8' });
       const destContent = fs.existsSync(destFile) ? fs.readFileSync(destFile, { encoding: 'utf-8' }) : null;
       if (srcContent !== destContent) {
         fs.writeFileSync(destFile, srcContent, { encoding: 'utf-8' });
-        console.debug('Wrote ' + destFile);
+        logger.debug('Wrote ' + destFile);
       }
     }
   }
@@ -330,7 +331,7 @@ export function syncDirs(srcDir: string, destDir: string, removeStale: boolean):
       const destFile = path.join(destDir, file);
       if (!fs.existsSync(srcFile) && fs.lstatSync(destFile).isFile()) {
         fs.unlinkSync(destFile);
-        console.debug('Removed stale file ' + destFile);
+        logger.debug('Removed stale file ' + destFile);
       }
     }
   }

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,0 +1,29 @@
+export class Logger {
+  constructor(public silent = false) { }
+
+  info(message: string, ...optionalParams: []) {
+    if (!this.silent) {
+      console.info(message, ...optionalParams);
+    }
+  }
+
+  log(message: string, ...optionalParams: []) {
+    if (!this.silent) {
+      console.log(message, ...optionalParams);
+    }
+  }
+
+  debug(message: string, ...optionalParams: []) {
+    if (!this.silent) {
+      console.debug(message, ...optionalParams);
+    }
+  }
+
+  warn(message: string, ...optionalParams: []) {
+    console.warn(message, ...optionalParams);
+  }
+
+  error(message: string, ...optionalParams: []) {
+    console.error(message, ...optionalParams);
+  }
+}

--- a/lib/operation.ts
+++ b/lib/operation.ts
@@ -8,6 +8,7 @@ import { Parameter } from './parameter';
 import { RequestBody } from './request-body';
 import { Response } from './response';
 import { Security } from './security';
+import { Logger } from './logger';
 
 /**
  * An operation descriptor
@@ -27,6 +28,7 @@ export class Operation {
   allResponses: Response[] = [];
   pathExpression: string;
   variants: OperationVariant[] = [];
+  logger: Logger;
 
   constructor(
     public openApi: OpenAPIObject,
@@ -36,6 +38,8 @@ export class Operation {
     public id: string,
     public spec: OperationObject,
     public options: Options) {
+
+    this.logger = new Logger(options.silent);
     this.path = this.path.replace(/\'/g, '\\\'');
     this.tags = spec.tags || [];
     this.pathVar = `${upperFirst(id)}Path`;
@@ -86,7 +90,7 @@ export class Operation {
         param = param as ParameterObject;
 
         if (param.in === 'cookie') {
-          console.warn(`Ignoring cookie parameter ${this.id}.${param.name} as cookie parameters cannot be sent in XmlHttpRequests.`);
+          this.logger.warn(`Ignoring cookie parameter ${this.id}.${param.name} as cookie parameters cannot be sent in XmlHttpRequests.`);
         } else if (this.paramIsNotExcluded(param)) {
           result.push(new Parameter(param as ParameterObject, this.options, this.openApi));
         }

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -105,4 +105,7 @@ export interface Options {
 
   /** When specified, will create temporary files in system temporary folder instead of next to output folder. */
   useTempDir?: boolean;
+
+  /** When true, no verbose output will be displayed */
+  silent?: boolean;
 }

--- a/ng-openapi-gen-schema.json
+++ b/ng-openapi-gen-schema.json
@@ -196,6 +196,11 @@
       "description": "When specified, will create temporary files in system temporary folder instead of output folder",
       "default": false,
       "type": "boolean"
+    },
+    "silent": {
+      "description": "When set to true, no verbose output will be displayed.",
+      "default": "false",
+      "type": "boolean"
     }
   }
 }


### PR DESCRIPTION
This adds an option "silent". If it is set to `true` not console messages (info, log, debug) are shown.
This is very useful if you call the generator from within another script.