### PR TITLE
Make valid method names from extension operation name

### DIFF
--- a/lib/operation.ts
+++ b/lib/operation.ts
@@ -1,7 +1,7 @@
 import { last, upperFirst } from 'lodash';
 import { ContentObject, MediaTypeObject, OpenAPIObject, OperationObject, ParameterObject, PathItemObject, ReferenceObject, RequestBodyObject, ResponseObject, SecurityRequirementObject, SecuritySchemeObject } from 'openapi3-ts';
 import { Content } from './content';
-import { resolveRef, typeName } from './gen-utils';
+import { methodName as genUtilsMethodName, resolveRef, typeName } from './gen-utils';
 import { OperationVariant } from './operation-variant';
 import { Options } from './options';
 import { Parameter } from './parameter';
@@ -39,7 +39,9 @@ export class Operation {
     this.path = this.path.replace(/\'/g, '\\\'');
     this.tags = spec.tags || [];
     this.pathVar = `${upperFirst(id)}Path`;
-    this.methodName = spec['x-operation-name'] || this.id;
+    this.methodName = spec['x-operation-name']
+      ? genUtilsMethodName(spec['x-operation-name'])
+      : this.id;
 
     // Add both the common and specific parameters
     this.parameters = [

--- a/test/all-operations.json
+++ b/test/all-operations.json
@@ -389,6 +389,22 @@
           }
         }
       }
+    },
+    "/path7": {
+      "get": {
+        "x-operation-name": "InPascalCase",
+        "responses": {
+          "200": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/test/all-operations.spec.ts
+++ b/test/all-operations.spec.ts
@@ -116,7 +116,7 @@ describe('Generation tests using all-operations.json', () => {
     const noTag = gen.services.get('noTag');
     expect(noTag).toBeDefined();
     if (!noTag) return;
-    expect(noTag.operations.length).toBe(4);
+    expect(noTag.operations.length).toBe(5);
 
     const ts = gen.templates.apply('service', noTag);
     const parser = new TypescriptParser();
@@ -161,6 +161,9 @@ describe('Generation tests using all-operations.json', () => {
 
       const withQuotes = cls.methods.find(m => m.name === 'withQuotes');
       expect(withQuotes).withContext(`method withQuotes`).toBeDefined();
+
+      const inPascalCase = cls.methods.find(m => m.name === 'inPascalCase');
+      expect(inPascalCase).withContext(`method in pascal case`).toBeDefined();
 
       done();
     });


### PR DESCRIPTION
When using an extension operation name, the name could not match the method naming convention, when it should.

I had to alias `methodName` as `genUtilsMethodName`, to not shadow `this.methodName` property. I am not a fan of this solution, tell me if you prefer another one.

