### PR TITLE
added support for explicit discriminator values on derived types

### DIFF
--- a/lib/gen-utils.ts
+++ b/lib/gen-utils.ts
@@ -217,6 +217,14 @@ export function tsType(schemaOrRef: SchemaOrRef | undefined, options: Options, o
     let result = '{\n';
     const properties = schema.properties || {};
     const required = schema.required;
+
+    for (const baseSchema of allOf) {
+      const discriminator = tryGetDiscriminator(baseSchema, schema, openApi);
+      if (discriminator) {
+        result += `'${discriminator.propName}': '${discriminator.value}';\n`;
+      }
+    }
+
     for (const propName of Object.keys(properties)) {
       const property = properties[propName];
       if (!property) {
@@ -342,4 +350,36 @@ export function syncDirs(srcDir: string, destDir: string, removeStale: boolean, 
       }
     }
   }
+}
+
+/**
+ * Tries to get a discriminator info from a base schema and for a derived one.
+ */
+function tryGetDiscriminator(baseSchemaOrRef: SchemaObject | ReferenceObject, derivedSchema: SchemaObject, openApi: OpenAPIObject) {
+  const baseSchema = (baseSchemaOrRef.$ref ? resolveRef(openApi, baseSchemaOrRef.$ref) : baseSchemaOrRef) as SchemaObject;
+  const discriminatorProp = baseSchema.discriminator?.propertyName;
+  if (discriminatorProp) {
+    const discriminatorValue = tryGetDiscriminatorValue(baseSchema, derivedSchema, openApi);
+    if (discriminatorValue) {
+      return {
+        propName: discriminatorProp,
+        value: discriminatorValue
+      };
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Tries to get a discriminator value from a base schema and for a derived one.
+ */
+function tryGetDiscriminatorValue(baseSchema: SchemaObject, derivedSchema: SchemaObject, openApi: OpenAPIObject): string | null {
+  const mapping = baseSchema.discriminator?.mapping;
+
+  if (mapping) {
+    const mappingIndex = Object.values(mapping).findIndex((ref) => resolveRef(openApi, ref) === derivedSchema);
+    return Object.keys(mapping)[mappingIndex] ?? null;
+  }
+
+  return null;
 }

--- a/test/polymorphic.json
+++ b/test/polymorphic.json
@@ -50,6 +50,57 @@
             "additionalProperties": false
           }
         }
+      },      
+      "Foo.Bar.DiscBase": {
+        "type": "object",
+        "required": [
+          "$type"
+        ],
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "$type": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "discriminator": {
+          "propertyName": "$type",
+          "mapping": {
+            "disc-1": "#/components/schemas/Foo.Bar.DiscOne",
+            "disc-2": "#/components/schemas/Foo.Bar.DiscTwo"
+          }
+        }
+      },
+      "Foo.Bar.DiscOne": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Foo.Bar.DiscBase"
+          }
+        ],
+        "properties": {
+          "discNumber": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Foo.Bar.DiscTwo": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Foo.Bar.DiscBase"
+          }
+        ],
+        "properties": {
+          "discText": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
       }
     }
   }

--- a/test/polymorphic.spec.ts
+++ b/test/polymorphic.spec.ts
@@ -37,4 +37,52 @@ describe('Generation of derived classes using polymorphic.json (as is generated 
       done();
     });
   });
+
+  it('DiscBase model', (done) => {
+    const baze = gen.models.get('Foo.Bar.DiscBase');
+    const ts = gen.templates.apply('model', baze);
+    const parser = new TypescriptParser();
+    parser.parseSource(ts).then((ast) => {
+      expect(ast.declarations.length).toBe(1);
+      expect(ast.declarations[0]).toEqual(jasmine.any(InterfaceDeclaration));
+      const decl = ast.declarations[0] as InterfaceDeclaration;
+      expect(decl.name).toBe('DiscBase');
+      expect(decl.properties).toHaveSize(2);
+      expect(decl.properties[0].name).toBe('$type');
+      expect(decl.properties[0].type).toBe('string');
+      expect(decl.properties[1].name).toBe('description');
+      expect(decl.properties[1].type).toBe('string');
+      done();
+    });
+  });
+
+  it('DiscOne model', (done) => {
+    const one = gen.models.get('Foo.Bar.DiscOne');
+    const ts = gen.templates.apply('model', one);
+    const parser = new TypescriptParser();
+    parser.parseSource(ts).then((ast) => {
+      expect(ast.declarations.length).toBe(1);
+      expect(ast.declarations[0]).toEqual(jasmine.any(TypeAliasDeclaration));
+      const decl = ast.declarations[0] as TypeAliasDeclaration;
+      expect(decl.name).toBe('DiscOne');
+      const text = ts.substring(decl.start || 0, decl.end || ts.length);
+      expect(text.replace(/\n/g, ' ')).toContain('DiscOne = FooBarDiscBase & { \'$type\': \'disc-1\'; \'discNumber\'?: number; }');
+      done();
+    });
+  });
+
+  it('DiscTwo model', (done) => {
+    const two = gen.models.get('Foo.Bar.DiscTwo');
+    const ts = gen.templates.apply('model', two);
+    const parser = new TypescriptParser();
+    parser.parseSource(ts).then((ast) => {
+      expect(ast.declarations.length).toBe(1);
+      expect(ast.declarations[0]).toEqual(jasmine.any(TypeAliasDeclaration));
+      const decl = ast.declarations[0] as TypeAliasDeclaration;
+      expect(decl.name).toBe('DiscTwo');
+      const text = ts.substring(decl.start || 0, decl.end || ts.length);
+      expect(text.replace(/\n/g, ' ')).toContain('DiscTwo = FooBarDiscBase & { \'$type\': \'disc-2\'; \'discText\'?: string; }');
+      done();
+    });
+  });
 });


### PR DESCRIPTION
Adds support for discriminator properties on derived types when used in conjuction with oneOf + allOf.

Fixes #227 