### PR TITLE
Fix model import with namespaces

### DIFF
--- a/lib/model.ts
+++ b/lib/model.ts
@@ -70,7 +70,9 @@ export class Model extends GenType {
 
   protected initPathToRoot(): string {
     if (this.namespace) {
-      return this.namespace.split('/').map(() => '../').join('/');
+      // for each namespace level go one directory up 
+      // plus the "models" directory
+      return this.namespace.split('/').map(() => '../').join('').concat('../');
     }
     return '../';
   }


### PR DESCRIPTION
Models with namespaces that have references between each other are broken since v0.50.

This is a simple openapi 3 definition with a model named "Ns.Ns2.Customer" referencing another one named "Ns.Address":
[openapi.json.txt](https://github.com/cyclosproject/ng-openapi-gen/files/12464071/openapi.json.txt)

The import to Customer in the API service is modeled correctly:
`import { Customer as NsNs2Customer } from '../models/Ns/Ns2/customer';`

However, the import from Customer to Address is broken:
`import { Address as NsAddress } from '..//../models/Ns/address';`

From what I found:
1. in lib/model.ts "pathToModels" creates the double "//" as it joins "../" with a "/"
2. in lib/imports.ts "add" seems to introduce the "models"

My idea (in this PR):
1. Remove the "/" in join of pathToModels
2. Add another "../" to get one level up of "model".

Models with namespaces that have references between each other are broken since v0.50.

This is a simple openapi 3 definition with a model named "Ns.Ns2.Customer" referencing another one named "Ns.Address":
[openapi.json.txt](https://github.com/cyclosproject/ng-openapi-gen/files/12463917/openapi.json.txt)

The import to Customer in the API service is modeled correctly:
`import { Customer as NsNs2Customer } from '../models/Ns/Ns2/customer';`

However, the import from Customer to Address is broken:
`import { Address as NsAddress } from '..//../models/Ns/address';`

From what I found:
1. in lib/model.ts "pathToModels" creates the double "//" as it joins "../" with a "/"
2. in lib/imports.ts "add" seems to introduce the "models"

My idea (in this PR): 
1. Remove the "/" in join of pathToModels
2. Add another "../" to get one level up of "models".