### PR TITLE
Adds option to maintain different media types of one one response type

### DIFF
--- a/lib/options.ts
+++ b/lib/options.ts
@@ -120,4 +120,15 @@ export interface Options {
 
   /** When true, no verbose output will be displayed */
   silent?: boolean;
+
+  /**
+   * When true, the expected response type in the request method names are not abbreviated and all response variants are kept.
+   * When array is given, `mediaType` is expected to be a RegExp string matching the response media type. The first match in the array
+   * will decide whether or how to shorten the media type. If no mediaType is given, it will always match.
+   *
+   * 'short':     application/x-spring-data-compact+json    ->    getEntities$Json
+   * 'tail':      application/x-spring-data-compact+json    ->    getEntities$XSpringDataCompactJson
+   * 'full':      application/x-spring-data-compact+json    ->    getEntities$ApplicationXSpringDataCompactJson
+   */
+  keepFullResponseMediaType?: boolean | Array<{ mediaType?: string; use: 'full' | 'tail' | 'short' }>;
 }

--- a/ng-openapi-gen-schema.json
+++ b/ng-openapi-gen-schema.json
@@ -217,6 +217,36 @@
       "description": "When set to true, no verbose output will be displayed.",
       "default": "false",
       "type": "boolean"
+    },
+    "keepFullResponseMediaType": {
+      "description": "When true, the expected response type in the request method names are not abbreviated and all response variants are kept.\\nWhen array is given, `mediaType` is expected to be a RegExp string matching the response media type. The first match in the array\\nwill decide whether or how to shorten the media type. If no mediaType is given, it will always match.\\n'short':     application/x-spring-data-compact+json    ->    getEntities$Json\\n'tail':      application/x-spring-data-compact+json    ->    getEntities$XSpringDataCompactJson\\n'full':      application/x-spring-data-compact+json    ->    getEntities$ApplicationXSpringDataCompactJson",
+      "default": "false",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "use"
+            ],
+            "properties": {
+              "mediaType": {
+                "type": "string"
+              },
+              "use": {
+                "enum": [
+                  "full",
+                  "tail",
+                  "short"
+                ]
+              }
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/test/all-operations.config.json
+++ b/test/all-operations.config.json
@@ -3,5 +3,17 @@
   "input": "all-operations.json",
   "output": "out/all-operations",
   "defaultTag": "noTag",
-  "excludeParameters": ["X-Exclude"]
+  "excludeParameters": [
+    "X-Exclude"
+  ],
+  "keepFullResponseMediaType": [
+    {
+      "mediaType": "spring",
+      "use": "full"
+    },
+    {
+      "mediaType": "hal\\+json",
+      "use": "tail"
+    }
+  ]
 }

--- a/test/all-operations.json
+++ b/test/all-operations.json
@@ -408,6 +408,66 @@
         }
       }
     },
+    "/path8": {
+      "get": {
+        "tags": [
+          "tag.tag2.tag3.tag4.tag5"
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/hal+json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/x-spring-data-compact+json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/uri-list": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "tag.tag2.tag3.tag4.tag5"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/duplicated1": {
       "get": {
         "operationId": "duplicated",

--- a/test/all-operations.spec.ts
+++ b/test/all-operations.spec.ts
@@ -20,7 +20,7 @@ describe('Generation tests using all-operations.json', () => {
   let gen: NgOpenApiGen;
 
   beforeEach(() => {
-    gen = new NgOpenApiGen(allOperationsSpec as OpenAPIObject, options);
+    gen = new NgOpenApiGen(allOperationsSpec as OpenAPIObject, options as any);
     gen.generate();
   });
 
@@ -532,5 +532,55 @@ describe('Generation tests using all-operations.json', () => {
     expect(operation.allResponses.length).toBe(1);
     const success = operation.successResponse;
     expect(success?.statusCode).toEqual('204');
+  });
+
+
+  it('GET /path8', () => {
+    const optionsWithCustomizedResponseType = { ...options } as Options;
+    gen = new NgOpenApiGen(allOperationsSpec as OpenAPIObject, optionsWithCustomizedResponseType);
+    gen.generate();
+    const operation = gen.operations.get('path8Get');
+    expect(operation).toBeDefined();
+
+    if (!operation) return;
+
+    // Assert each variant
+    const vars = operation.variants;
+    expect(vars.length).toBe(4);
+
+    const jsonPlain = vars[0];
+    expect(jsonPlain.responseType).toBe('json');
+    expect(jsonPlain.methodName).toBe('path8Get$Json');
+
+    const halJsonPlain = vars[1];
+    expect(halJsonPlain.responseType).toBe('json');
+    expect(halJsonPlain.methodName).toBe('path8Get$HalJson');
+
+    const compactJsonPlain = vars[2];
+    expect(compactJsonPlain.responseType).toBe('json');
+    expect(compactJsonPlain.methodName).toBe('path8Get$ApplicationXSpringDataCompactJson');
+
+    const text = vars[3];
+    expect(text.responseType).toBe('text');
+    expect(text.methodName).toBe('path8Get$UriList');
+  });
+
+
+  it('POST /path8', () => {
+    const optionsWithCustomizedResponseType = { ...options } as Options;
+    gen = new NgOpenApiGen(allOperationsSpec as OpenAPIObject, optionsWithCustomizedResponseType);
+    gen.generate();
+    const operation = gen.operations.get('path8Post');
+    expect(operation).toBeDefined();
+    expect(operation?.variants[0].responseType).toBe('json');
+
+    if (!operation) return;
+
+    // Assert each variant
+    const vars = operation.variants;
+    expect(vars.length).toBe(1);
+
+    const jsonPlain = vars[0];
+    expect(jsonPlain.methodName).toBe('path8Post');
   });
 });


### PR DESCRIPTION
I started to use your project to generate my Angular client, but soon stumbled on the problem described in #183, so I offer an opt-in solution here.

I added the option `keepFullResponseMediaType`, where one can choose which media type should be shortened to `$Json` or which should be kept in whole.

Specifically, when true, the expected response type in the request method names are not abbreviated and all response variants are kept.
When array is given, `mediaType` is expected to be a RegExp string matching the response media type. The first match in the array
will decide whether or how to shorten the media type. If no mediaType is given, it will always match.

| option value | media type | variant method name |
|-----|---|---|
| short |     application/x-spring-data-compact+json    |   getEntities$Json
| tail |        application/x-spring-data-compact+json    |    getEntities$XSpringDataCompactJson
| full |        application/x-spring-data-compact+json    |    getEntities$ApplicationXSpringDataCompactJson