### PR TITLE
Do not emit an empty module export in the index if no module is required

### DIFF
--- a/templates/index.handlebars
+++ b/templates/index.handlebars
@@ -6,7 +6,9 @@ export { {{configurationClass}} } from './{{{configurationFile}}}';
 export { {{baseServiceClass}} } from './{{{baseServiceFile}}}';
 export { {{requestBuilderClass}} } from './{{{requestBuilderFile}}}';
 export { {{responseClass}} } from './{{{responseFile}}}';
+{{#if moduleClass}}
 export { {{moduleClass}} } from './{{{moduleFile}}}';
+{{/if}}
 {{#modelIndex.imports}}export { {{{typeName}}}{{#useAlias}} as {{{qualifiedName}}}{{/useAlias}} } from './models{{{file}}}';
 {{/modelIndex.imports}}
 {{#services}}export { {{typeName}} } from './services/{{{fileName}}}';

--- a/test/all-types.spec.ts
+++ b/test/all-types.spec.ts
@@ -1,5 +1,5 @@
 import { OpenAPIObject } from '@loopback/openapi-v3-types';
-import { ClassDeclaration, EnumDeclaration, InterfaceDeclaration, TypeAliasDeclaration, TypescriptParser } from 'typescript-parser';
+import { ClassDeclaration, EnumDeclaration, InterfaceDeclaration, NamedExport, TypeAliasDeclaration, TypescriptParser } from 'typescript-parser';
 import { NgOpenApiGen } from '../lib/ng-openapi-gen';
 import { Options } from '../lib/options';
 import options from './all-types.config.json';
@@ -523,6 +523,21 @@ describe('Generation tests using all-types.json', () => {
       const text = ts.substring(decl.start || 0, decl.end || ts.length);
       expect(text).toContain('Circle = Shape & {');
       expect(text).toContain('\'radius\'?: number');
+      done();
+    });
+  });
+
+  it('index file', done => {
+    const ref = gen.models.get('InlineObject');
+    const ts = gen.templates.apply('index', ref);
+    const parser = new TypescriptParser();
+    parser.parseSource(ts).then(ast => {
+      expect(ast.exports.length).withContext('Has the correct number of exports').toBe(5);
+      expect(ast.exports.some((ex: NamedExport) => ex.from === './api-configuration')).withContext('Has an ApiConfiguration export').toBeDefined();
+      expect(ast.exports.some((ex: NamedExport) => ex.from === './base-service')).withContext('Has a BaseService export').toBeDefined();
+      expect(ast.exports.some((ex: NamedExport) => ex.from === './request-builder')).withContext('Has a RequestBuilder export').toBeDefined();
+      expect(ast.exports.some((ex: NamedExport) => ex.from === './strict-http-response')).withContext('Has a StrictHttpResponse export').toBeDefined();
+      expect(ast.exports.some((ex: NamedExport) => ex.from === './api.module')).withContext('Has an ApiModule export').toBeDefined();
       done();
     });
   });

--- a/test/noModule.config.json
+++ b/test/noModule.config.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../ng-openapi-gen-schema.json",
+  "input": "test/noModule.json",
+  "output": "out/noModule",
+  "useTempDir": true,
+  "module": false,
+  "indexFile": true
+}

--- a/test/noModule.json
+++ b/test/noModule.json
@@ -1,0 +1,25 @@
+{
+  "openapi": "3.0",
+  "info": {
+    "title": "Test with noModule",
+    "version": "1.0"
+  },
+  "paths": {
+    "/foo": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/plain": {}
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/noModule.spec.ts
+++ b/test/noModule.spec.ts
@@ -1,0 +1,28 @@
+import { OpenAPIObject } from 'openapi3-ts';
+import { NgOpenApiGen } from '../lib/ng-openapi-gen';
+import options from './noModule.config.json';
+import templatesSpec from './noModule.json';
+import { NamedExport, TypescriptParser } from 'typescript-parser';
+
+describe('Generation tests with index and no ApiModule', () => {
+  const gen = new NgOpenApiGen(templatesSpec as OpenAPIObject, options);
+
+  beforeAll(() => {
+    gen.generate();
+  });
+
+  it('index file', done => {
+    const ref = gen.models.get('InlineObject');
+    const ts = gen.templates.apply('index', ref);
+    const parser = new TypescriptParser();
+    parser.parseSource(ts).then(ast => {
+      expect(ast.exports.length).withContext('Has the correct number of exports').toBe(4);
+      expect(ast.exports.some((ex: NamedExport) => ex.from === './api-configuration')).withContext('Has an ApiConfiguration export').toBeDefined();
+      expect(ast.exports.some((ex: NamedExport) => ex.from === './base-service')).withContext('Has a BaseService export').toBeDefined();
+      expect(ast.exports.some((ex: NamedExport) => ex.from === './request-builder')).withContext('Has a RequestBuilder export').toBeDefined();
+      expect(ast.exports.some((ex: NamedExport) => ex.from === './strict-http-response')).withContext('Has a StrictHttpResponse export').toBeDefined();
+      done();
+    });
+  });
+
+});


### PR DESCRIPTION
# Problem

See #337 

We might not want a module but still want an index, e.g.:
```json
{
  "module": false,
  "indexFile": true
}
```

In such a case, we'd get something like:
```typescript
/* tslint:disable */
/* eslint-disable */
/* Code generated by ng-openapi-gen DO NOT EDIT. */

export { ApiConfiguration } from './api-configuration';
export { BaseService } from './base-service';
export { RequestBuilder } from './request-builder';
export { StrictHttpResponse } from './strict-http-response';
export {  } from './';   // <----------------------------------------- Note this broken export
export { ApiService } from './services/api.service';
```

# Solution

Guard the export in the template. Be sure to not break things by writing tests for the exports in `index.ts` for both cases - whenever `module` is on or off.

# Testing done

Verified the output no longer contains such an export in that case.

Verified the existing exports are not regressed.

Compared the test output before and after the fix:
```
$ diff -r out-before out-after
diff --color -r out-before/all-operations/fn/no-tag/path-6-get.ts out-after/all-operations/fn/no-tag/path-6-get.ts
21c21
<     rb.build({ responseType: 'arraybuffer', accept: '*/*', context })
---
>     rb.build({ responseType: 'blob', accept: '*/*', context })
diff --color -r out-before/noModule/index.ts out-after/noModule/index.ts
9d8
< export {  } from './';
```

(The diff in `path-6-get.ts` seems unrelated, probably due to non-determinism)