### PR TITLE
Support const

### DIFF
--- a/lib/gen-utils.ts
+++ b/lib/gen-utils.ts
@@ -250,7 +250,7 @@ function rawTsType(schema: SchemaObject, options: Options, openApi: OpenAPIObjec
   }
 
   // Inline enum
-  const enumValues = schema.enum || [];
+  const enumValues = schema.enum || ((schema as any).const ? [(schema as any).const] : []);
   if (enumValues.length > 0) {
     if (type === 'number' || type === 'integer' || type === 'boolean') {
       return enumValues.join(' | ');

--- a/test/const.config.json
+++ b/test/const.config.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../ng-openapi-gen-schema.json",
+  "input": "enums.json"
+}

--- a/test/const.json
+++ b/test/const.json
@@ -1,0 +1,42 @@
+{
+  "openapi": "3.0",
+  "info": {
+    "title": "Test generation styles of const",
+    "version": "1.0"
+  },
+  "components" : {
+    "schemas" : {
+      "FlavorConst" : {
+        "description" : "Some ice-cream flavors",
+        "type" : "object",
+        "required" : [ "flavor" ],
+        "properties" : {
+          "flavor" : {
+            "type" : "string",            
+            "const" : "IonlyWantChocolate"
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/foo": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/FlavorConst"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/const.spec.ts
+++ b/test/const.spec.ts
@@ -1,0 +1,20 @@
+import { OpenAPIObject } from 'openapi3-ts';
+import { NgOpenApiGen } from '../lib/ng-openapi-gen';
+import options from './const.config.json';
+import constsSpec from './const.json';
+import * as fs from 'fs';
+import { Options } from '../lib/options';
+
+describe('Test const generation', () => {
+
+  it('const', () => {
+    const genDefault = new NgOpenApiGen(constsSpec as OpenAPIObject, {
+      ...options,
+      output: 'out/constStyle/default/'
+    } as Options);
+    genDefault.generate();
+    const fileContents = fs.readFileSync(fs.realpathSync(`${genDefault.outDir}/models/flavor-const.ts`));
+    expect(/flavor: 'IonlyWantChocolate'/.test(fileContents.toString())).toBeTrue();
+  });
+
+});


### PR DESCRIPTION
Since the base TypeScript Types of @loopback/openapi-v3-types are fairly outdated, the don't contain "const". I think it would be best to inline those entirely, but that's another project.

So here I just use dirty `any`. 