### PR TITLE
fix: Properly append a $ suffix to reserved words in index files

### DIFF
--- a/lib/ng-openapi-gen.ts
+++ b/lib/ng-openapi-gen.ts
@@ -24,6 +24,7 @@ import { Options } from './options';
 import { Service } from './service';
 import { Templates } from './templates';
 import { ModelIndex } from './model-index';
+import { OperationVariant } from './operation-variant';
 
 /**
  * Main generator class
@@ -35,6 +36,7 @@ export class NgOpenApiGen {
   models = new Map<string, Model>();
   services = new Map<string, Service>();
   operations = new Map<string, Operation>();
+  functions: OperationVariant[] = [];
   outDir: string;
   logger: Logger;
   tempDir: string;
@@ -115,16 +117,16 @@ export class NgOpenApiGen {
       ], []);
 
       // Remove duplicates
-      const functions = allFunctions.filter((fn, index, arr) =>
+      this.functions = allFunctions.filter((fn, index, arr) =>
         arr.findIndex(f => f.methodName === fn.methodName) === index
       );
 
-      for (const fn of functions) {
+      for (const fn of this.functions) {
         this.write('fn', fn, fn.importFile, fn.importPath);
       }
 
       // Context object passed to general templates
-      const general = { services, models, functions };
+      const general = { services, models, functions: this.functions };
 
       // Generate the general files
       this.write('configuration', general, this.globals.configurationFile);

--- a/templates/index.handlebars
+++ b/templates/index.handlebars
@@ -14,5 +14,5 @@ export type { {{responseClass}} } from './{{{responseFile}}}';
 {{#services}}export { {{typeName}} } from './services/{{{fileName}}}';
 {{/services}}{{/if}}
 {{#functions}}export type { {{paramsType}} } from './{{{importPath}}}/{{{importFile}}}';
-export { {{methodName}} } from './{{{importPath}}}/{{{importFile}}}';
+export { {{importName}} } from './{{{importPath}}}/{{{importFile}}}';
 {{/functions}}

--- a/test/reservedWords.config.json
+++ b/test/reservedWords.config.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../ng-openapi-gen-schema.json",
+  "input": "test/reservedWords.json",
+  "output": "out/reservedWords",
+  "useTempDir": true,
+  "indexFile": true
+}

--- a/test/reservedWords.json
+++ b/test/reservedWords.json
@@ -1,0 +1,25 @@
+{
+  "openapi": "3.0",
+  "info": {
+    "title": "Test with noModule",
+    "version": "1.0"
+  },
+  "paths": {
+    "/foo": {
+      "get": {
+        "operationId": "import",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/reservedWords.spec.ts
+++ b/test/reservedWords.spec.ts
@@ -1,0 +1,33 @@
+import { NgOpenApiGen } from '../lib/ng-openapi-gen';
+import { OpenAPIObject } from '../lib/openapi-typings';
+import options from './reservedWords.config.json';
+import templatesSpec from './reservedWords.json';
+import { TypescriptParser } from 'typescript-parser';
+
+const spec = templatesSpec as unknown as OpenAPIObject;
+
+describe('Generation tests with reserved words', () => {
+  const gen = new NgOpenApiGen(spec, options);
+
+  beforeAll(() => {
+    gen.generate();
+  });
+
+  it('index file', () => {
+    const general = { models: gen.models, functions: gen.functions };
+    const ts = gen.templates.apply('index', general);
+    const parser = new TypescriptParser();
+    parser.parseSource(ts).then(ast => {
+      expect(ast.exports.length).toBe(6);
+      expect(ast.exports[4]).toMatchObject({
+        from: './fn/operations/import',
+        specifiers: [{ specifier: 'Import$Params' }]
+      });
+      expect(ast.exports[5]).toMatchObject({
+        from: './fn/operations/import',
+        specifiers: [{ specifier: 'import$' }]
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
# Problem

See #383.

Long story short, exports that use reserved keywords (e.g. `import`) in `index.ts` files (when `"indexFile": true`) do not have the `$` prefix used everywhere else in the emitted code. As a result, the `index.ts` would reference `import` which is `import$` everywhere else. This leads to TS code that does not compile.

# Solution

The `ensureNotReserved` helper applies the `$` suffix. It's already applieds on the `methodName` to produce `importName`. However, the `index.ts` template references `methodName` and not the `importName`.

This change switches the template to `importName`.

Also wrote a test for the problematic case, that fails without the current fix. To use the generated `functions` in the test, I had to expose them from `ng-openapi-gen.ts`.