### PR TITLE
fix: empty export of apiServiceClass if not provided

### DIFF
--- a/templates/index.handlebars
+++ b/templates/index.handlebars
@@ -3,7 +3,9 @@
 
 export { {{configurationClass}} } from './{{{configurationFile}}}';
 export { {{requestBuilderClass}} } from './{{{requestBuilderFile}}}';
+{{#if apiServiceClass}}
 export { {{apiServiceClass}} } from './{{{apiServiceFile}}}';
+{{/if}}
 {{#if moduleClass}}
 export { {{moduleClass}} } from './{{{moduleFile}}}';
 {{/if}}


### PR DESCRIPTION
Solves https://github.com/cyclosproject/ng-openapi-gen/issues/386

As I see that a [similar fix](https://github.com/cyclosproject/ng-openapi-gen/commit/b3516402485d0e5a2bcead6175cbb81d3f8c6aec) had changed some more files this simple fix might not be enough. But at least the correct place to begin with can be found here :D

Simply close if this should be fixed with some more rework :)