### PR TITLE
Fix imports when type is an array with 'array' type

### DIFF
--- a/lib/openapi-typings.ts
+++ b/lib/openapi-typings.ts
@@ -45,7 +45,7 @@ export function isArraySchemaObject(obj: SchemaObject): obj is ArraySchemaObject
     return true;
   }
   // OpenAPI 3.1 allows 'type' to be an array of types, so we need to check if it includes 'array'
-  if (Array.isArray(obj.type) && obj.type.includes('array' as any)) {
+  if (Array.isArray(obj.type) && obj.type.includes('array')) {
     return true;
   }
   return false;


### PR DESCRIPTION
If you have an openapi schema with a nullable array property, like this:
```json
"campaigns": {
  "type": [
    "null",
    "array"
  ],
  "items": {
    "$ref": "#/components/schemas/Campaign"
  }
},
```

The imports will not be collected and the rendered typescript file will fail to compile, because isArraySchemaObject is not handling the case where "type" is an array.

This should fix that.