### PR TITLE
fix(codegen): strip spaces from tag names when generating functions

### DIFF
--- a/lib/ng-openapi-gen.ts
+++ b/lib/ng-openapi-gen.ts
@@ -1,6 +1,6 @@
 import $RefParser from '@apidevtools/json-schema-ref-parser';
 import eol from 'eol';
-import { upperFirst } from 'lodash';
+
 
 // Import centralized OpenAPI types and utilities
 import {
@@ -15,7 +15,7 @@ import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
 import { parseOptions } from './cmd-args';
-import { HTTP_METHODS, deleteDirRecursive, methodName, simpleName, syncDirs, resolveRef } from './gen-utils';
+import { HTTP_METHODS, deleteDirRecursive, methodName, simpleName, syncDirs, typeName, resolveRef } from './gen-utils';
 import { Globals } from './globals';
 import { HandlebarsManager } from './handlebars-manager';
 import { Logger } from './logger';
@@ -126,7 +126,7 @@ export class NgOpenApiGen {
       for (const fn of functions) {
         const isDuplicate = (methodNameCounts.get(fn.methodName) || 0) > 1;
         if (isDuplicate) {
-          const tagSuffix = upperFirst(fn.operation.tag);
+          const tagSuffix = typeName(fn.operation.tag);
           fn.exportName = fn.methodName + tagSuffix;
           fn.paramsTypeExportName = fn.paramsType.replace('$Params', '') + tagSuffix + '$Params';
         } else {

--- a/lib/ng-openapi-gen.ts
+++ b/lib/ng-openapi-gen.ts
@@ -1,7 +1,6 @@
 import $RefParser from '@apidevtools/json-schema-ref-parser';
 import eol from 'eol';
 
-
 // Import centralized OpenAPI types and utilities
 import {
   OpenAPIObject,

--- a/test/duplicate-x-operation-name.json
+++ b/test/duplicate-x-operation-name.json
@@ -42,6 +42,25 @@
           }
         }
       }
+    },
+    "/api/electric-sports-car/consumption": {
+      "get": {
+        "x-controller-name": "ElectricSportsCar",
+        "x-operation-name": "getConsumption",
+        "tags": ["Electric Sports Car"],
+        "responses": {
+          "200": {
+            "description": "Consumption",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/test/duplicate-x-operation-name.spec.ts
+++ b/test/duplicate-x-operation-name.spec.ts
@@ -9,22 +9,24 @@ const gen = new NgOpenApiGen(spec as OpenAPIObject, options as Options);
 gen.generate();
 
 describe('Generation tests using duplicate-x-operation-name.json', () => {
-  it('index.ts should have both functions and parameters', () => {
-    // Read file options.output + '/index.ts'
+  it('index.ts should have all functions and parameters', () => {
     const content = fs.readFileSync(options.output + '/index.ts', 'utf8');
     expect(content).toContain('export { getConsumption as getConsumptionCar }');
     expect(content).toContain('export type { GetConsumption$Params as GetConsumptionCar$Params }');
     expect(content).toContain('export { getConsumption as getConsumptionPlane }');
     expect(content).toContain('export type { GetConsumption$Params as GetConsumptionPlane$Params }');
+    expect(content).toContain('export { getConsumption as getConsumptionElectricSportsCar }');
+    expect(content).toContain('export type { GetConsumption$Params as GetConsumptionElectricSportsCar$Params }');
   });
 
-  it('functions.ts should have both functions and parameters', () => {
-    // Read file options.output + '/functions.ts'
+  it('functions.ts should have all functions and parameters', () => {
     const content = fs.readFileSync(options.output + '/functions.ts', 'utf8');
     expect(content).toContain('export { getConsumption as getConsumptionCar }');
     expect(content).toContain('export type { GetConsumption$Params as GetConsumptionCar$Params }');
     expect(content).toContain('export { getConsumption as getConsumptionPlane }');
     expect(content).toContain('export type { GetConsumption$Params as GetConsumptionPlane$Params }');
+    expect(content).toContain('export { getConsumption as getConsumptionElectricSportsCar }');
+    expect(content).toContain('export type { GetConsumption$Params as GetConsumptionElectricSportsCar$Params }');
   });
 
 });

--- a/test/duplicate-x-operation-name.spec.ts
+++ b/test/duplicate-x-operation-name.spec.ts
@@ -9,7 +9,7 @@ const gen = new NgOpenApiGen(spec as OpenAPIObject, options as Options);
 gen.generate();
 
 describe('Generation tests using duplicate-x-operation-name.json', () => {
-  it('index.ts should have all functions and parameters', () => {
+  it('index.ts should have both functions and parameters', () => {
     // Read file options.output + '/index.ts'
     const content = fs.readFileSync(options.output + '/index.ts', 'utf8');
     expect(content).toContain('export { getConsumption as getConsumptionCar }');
@@ -20,7 +20,7 @@ describe('Generation tests using duplicate-x-operation-name.json', () => {
     expect(content).toContain('export type { GetConsumption$Params as GetConsumptionElectricSportsCar$Params }');
   });
 
-  it('functions.ts should have all functions and parameters', () => {
+  it('functions.ts should have both functions and parameters', () => {
     // Read file options.output + '/functions.ts'
     const content = fs.readFileSync(options.output + '/functions.ts', 'utf8');
     expect(content).toContain('export { getConsumption as getConsumptionCar }');

--- a/test/duplicate-x-operation-name.spec.ts
+++ b/test/duplicate-x-operation-name.spec.ts
@@ -10,6 +10,7 @@ gen.generate();
 
 describe('Generation tests using duplicate-x-operation-name.json', () => {
   it('index.ts should have all functions and parameters', () => {
+    // Read file options.output + '/index.ts'
     const content = fs.readFileSync(options.output + '/index.ts', 'utf8');
     expect(content).toContain('export { getConsumption as getConsumptionCar }');
     expect(content).toContain('export type { GetConsumption$Params as GetConsumptionCar$Params }');
@@ -20,6 +21,7 @@ describe('Generation tests using duplicate-x-operation-name.json', () => {
   });
 
   it('functions.ts should have all functions and parameters', () => {
+    // Read file options.output + '/functions.ts'
     const content = fs.readFileSync(options.output + '/functions.ts', 'utf8');
     expect(content).toContain('export { getConsumption as getConsumptionCar }');
     expect(content).toContain('export type { GetConsumption$Params as GetConsumptionCar$Params }');


### PR DESCRIPTION
Fixes a small regression from https://github.com/cyclosproject/ng-openapi-gen/commit/ee7f654, where OAS tags with spaces in them incorrectly generate function definitions with spaces.